### PR TITLE
SEO: migrate to Next.js Metadata API + per-route metadata (SOR-14/SOR-5)

### DIFF
--- a/docs/audio-system-redesign.md
+++ b/docs/audio-system-redesign.md
@@ -1,0 +1,100 @@
+# Audio System Redesign
+
+## Problem
+
+The current `useAudioManager` hook is imported into dozens of components, tightly coupling audio feedback to UI logic. Every component that plays a sound must:
+
+1. Be a client component
+2. Import and call the hook
+3. Manually wire `playSound` to event handlers
+
+This creates a wide dependency surface and prevents components from being server components.
+
+## Recommendation
+
+Replace per-component `useAudioManager` usage with a **declarative, attribute-based approach** using a single global event listener.
+
+### Current Pattern (avoid)
+
+```tsx
+'use client';
+import { useAudioManager } from '../../hooks/useAudioManager';
+
+export function MenuItem({ label }: { label: string }) {
+  const { playSound } = useAudioManager();
+  return (
+    <button
+      onMouseEnter={() => playSound('hover')}
+      onClick={() => playSound('click')}
+    >
+      {label}
+    </button>
+  );
+}
+```
+
+### Recommended Pattern
+
+```tsx
+// Component — can be a server component now
+export function MenuItem({ label }: { label: string }) {
+  return (
+    <button data-sound-hover="hover" data-sound-click="click">
+      {label}
+    </button>
+  );
+}
+```
+
+```tsx
+// Single global listener — mounted once at the root
+'use client';
+
+import { useEffect } from 'react';
+import { useAudioManager } from '../hooks/useAudioManager';
+
+export function GlobalSoundProvider({ children }: { children: React.ReactNode }) {
+  const { playSound } = useAudioManager();
+
+  useEffect(() => {
+    const handleMouseEnter = (e: Event) => {
+      const target = (e.target as HTMLElement).closest('[data-sound-hover]');
+      if (target) {
+        const sound = target.getAttribute('data-sound-hover');
+        if (sound) playSound(sound);
+      }
+    };
+
+    const handleClick = (e: Event) => {
+      const target = (e.target as HTMLElement).closest('[data-sound-click]');
+      if (target) {
+        const sound = target.getAttribute('data-sound-click');
+        if (sound) playSound(sound);
+      }
+    };
+
+    document.addEventListener('mouseenter', handleMouseEnter, true);
+    document.addEventListener('click', handleClick, true);
+    return () => {
+      document.removeEventListener('mouseenter', handleMouseEnter, true);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [playSound]);
+
+  return children;
+}
+```
+
+## Benefits
+
+- Components no longer need `'use client'` just for audio
+- Audio behavior is declarative and visible in markup
+- Single place to modify audio logic (volume, muting, new event types)
+- The existing audio pooling system (`useAudioManager`) stays unchanged — only the wiring changes
+
+## Migration Strategy
+
+1. Create `GlobalSoundProvider` and mount it in the root layout
+2. Migrate one page at a time: replace `playSound` calls with `data-sound-*` attributes
+3. Remove `useAudioManager` imports from migrated components
+4. Keep `useAudioManager` available for edge cases that need imperative control (e.g., playing sound on data fetch completion)

--- a/docs/component-structure.md
+++ b/docs/component-structure.md
@@ -1,0 +1,58 @@
+# Component Structure
+
+## Current State
+
+The codebase already uses some good patterns:
+- CSS Modules for scoped styling
+- `PageLayout` compound component (`PageLayout.Header`, `PageLayout.Body`)
+- `React.memo` for performance-critical components
+
+## Recommendations
+
+### Lean Into Compound Components
+
+The `PageLayout` pattern is good — extend it to other complex components:
+
+```tsx
+// Example: ProjectCard compound component
+<ProjectCard>
+  <ProjectCard.Header title="sorOS" date="2025" />
+  <ProjectCard.Tech items={['Next.js', 'tRPC', 'Prisma']} />
+  <ProjectCard.Description>
+    Xbox 360-inspired portfolio website.
+  </ProjectCard.Description>
+  <ProjectCard.Links github="..." live="..." />
+</ProjectCard>
+```
+
+This is more flexible than a single component with 10+ props and makes the markup self-documenting.
+
+### Skip Storybook (Unless Actively Used)
+
+Storybook adds maintenance overhead:
+- Stories go stale when components change
+- Extra dev dependency and config to maintain
+- Build time increases
+
+For a personal portfolio, **use the actual pages as your component playground**. The existing `/design-system` page already serves this purpose. Keep Storybook only if you're actively using it during development.
+
+### File Structure
+
+Keep the current flat component structure but be consistent:
+
+```
+src/components/
+  PageLayout/
+    PageLayout.tsx
+    PageLayout.module.css
+    index.ts              ← re-export for clean imports
+  ProjectCard/
+    ProjectCard.tsx
+    ProjectCard.module.css
+    ProjectCard.test.tsx  ← only if the component has complex logic
+    index.ts
+```
+
+### Avoid Over-Abstraction
+
+Don't create wrapper components unless they're used in 3+ places. Three similar lines of JSX is better than a premature `<IconLabel>` abstraction.

--- a/docs/context-simplification.md
+++ b/docs/context-simplification.md
@@ -1,0 +1,122 @@
+# Context Simplification
+
+## Problem
+
+The root layout nests 6 context providers deep:
+
+```tsx
+<BackgroundProvider>
+  <CRTFilterProvider>
+    <TRPCProvider>
+      <VolumeProvider>
+        <WMPPlayerProvider>
+          <ToastProvider>
+            {children}
+          </ToastProvider>
+        </WMPPlayerProvider>
+      </VolumeProvider>
+    </TRPCProvider>
+  </CRTFilterProvider>
+</BackgroundProvider>
+```
+
+This creates several issues:
+- Every context change re-renders all consumers (React Context has no selector support)
+- Deep nesting makes the provider tree hard to reason about
+- All providers load on every route, even if unused
+
+## Recommendation
+
+### Option A: Consolidate with Zustand (Recommended)
+
+Replace multiple React contexts with a single Zustand store. Zustand supports selectors natively, preventing unnecessary re-renders.
+
+```tsx
+// src/store/useAppStore.ts
+import { create } from 'zustand';
+
+interface AppState {
+  // Volume
+  volume: number;
+  setVolume: (v: number) => void;
+
+  // Background
+  background: string;
+  setBackground: (bg: string) => void;
+
+  // CRT Filter
+  crtEnabled: boolean;
+  setCrtEnabled: (enabled: boolean) => void;
+
+  // WMP Player
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  playTrack: (track: Track) => void;
+  pause: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  volume: 0.5,
+  setVolume: (volume) => set({ volume }),
+
+  background: 'default',
+  setBackground: (background) => set({ background }),
+
+  crtEnabled: true,
+  setCrtEnabled: (crtEnabled) => set({ crtEnabled }),
+
+  currentTrack: null,
+  isPlaying: false,
+  playTrack: (track) => set({ currentTrack: track, isPlaying: true }),
+  pause: () => set({ isPlaying: false }),
+}));
+```
+
+Usage — components only re-render when their selected slice changes:
+
+```tsx
+const volume = useAppStore((s) => s.volume);
+const setVolume = useAppStore((s) => s.setVolume);
+```
+
+### Option B: Merge Related Contexts
+
+If staying with React Context, at minimum combine related concerns:
+
+- `BackgroundProvider` + `CRTFilterProvider` → `VisualEffectsProvider`
+- `VolumeProvider` + `WMPPlayerProvider` → `AudioProvider`
+
+This reduces nesting from 6 levels to 3-4.
+
+### Scope tRPC Provider
+
+Move `TRPCProvider` out of the root layout and into only the routes that need it (blog, chatroom, profile, music). Use a route group:
+
+```
+src/app/
+  (with-trpc)/
+    layout.tsx       ← TRPCProvider here
+    blog/
+    chatroom/
+    music/
+  (static)/
+    layout.tsx       ← no TRPCProvider
+    about/
+    projects/
+    certifications/
+```
+
+## Benefits
+
+- Fewer re-renders from unrelated state changes
+- Lighter initial bundle for static pages
+- Easier to debug state with Zustand devtools
+- Cleaner root layout
+
+## Migration Strategy
+
+1. Install Zustand (`npm install zustand`)
+2. Create `useAppStore` combining Volume + Background + CRT state
+3. Migrate one context at a time, starting with the simplest (CRTFilter)
+4. Keep Toast as a separate context (or use a dedicated library like Sonner)
+5. Move TRPCProvider to a route group for dynamic pages

--- a/docs/data-colocation.md
+++ b/docs/data-colocation.md
@@ -1,0 +1,78 @@
+# Data Colocation
+
+## Problem
+
+Blog content is fetched at runtime from Medium's RSS feed via a tRPC endpoint. This introduces:
+
+- A runtime dependency on Medium's availability
+- Latency on every page load
+- No control over content formatting or metadata
+- Can't add custom fields (cover images, tags, reading time)
+
+Static data lives in `src/data/*.json` files, which works well for structured data but doesn't support rich content.
+
+## Recommendation
+
+### Blog Posts: Use MDX
+
+Replace the Medium RSS dependency with local MDX files. Next.js has built-in MDX support.
+
+```
+src/
+  content/
+    blog/
+      building-soros.mdx
+      xbox-dashboard-css.mdx
+  data/
+    projects.json        ← keep as-is
+    certifications.json  ← keep as-is
+```
+
+Each MDX file includes frontmatter for metadata:
+
+```mdx
+---
+title: "Building sorOS"
+date: "2025-06-15"
+description: "How I built an Xbox 360 dashboard replica with Next.js"
+coverImage: "/assets/blog/building-soros.jpg"
+tags: ["nextjs", "css", "portfolio"]
+---
+
+Article content with **rich formatting**, code blocks, and embedded components.
+```
+
+Benefits:
+- **Full control** over content and formatting
+- **No runtime dependency** — content is compiled at build time
+- **Type-safe frontmatter** with a Zod schema
+- **Custom components** embeddable in posts (demos, interactive examples)
+- **Better SEO** — each post can have its own metadata, JSON-LD, and OG image
+
+### Structured Data: Keep JSON
+
+`projects.json`, `certifications.json`, and similar files work well as-is. Consider adding a light Zod validation layer to catch schema issues at build time:
+
+```tsx
+import { z } from 'zod';
+import projectsRaw from '../data/projects.json';
+
+const ProjectSchema = z.object({
+  projectName: z.string(),
+  role: z.string(),
+  date: z.string(),
+  description: z.string(),
+  keyTechnologies: z.array(z.string()),
+});
+
+export const projects = z.array(ProjectSchema).parse(projectsRaw);
+```
+
+## Migration Strategy
+
+1. Install `@next/mdx` and configure `next.config.js`
+2. Export existing Medium posts as MDX files
+3. Create a `src/content/blog/` directory with frontmatter schema
+4. Build a `getAllPosts()` utility that reads and sorts MDX files
+5. Keep the Medium tRPC endpoint temporarily as a fallback
+6. Remove the Medium dependency once content is migrated

--- a/docs/performance-optimizations.md
+++ b/docs/performance-optimizations.md
@@ -1,0 +1,93 @@
+# Performance Optimizations
+
+## Dynamic Imports for Heavy Pages
+
+Some pages load large dependencies that aren't needed on initial navigation. Use `next/dynamic` to code-split them:
+
+```tsx
+// src/app/design-system/page.tsx
+import dynamic from 'next/dynamic';
+
+const ColorTab = dynamic(() => import('./tabs/ColorTab'), {
+  loading: () => <TabSkeleton />,
+});
+
+const TypographyTab = dynamic(() => import('./tabs/TypographyTab'), {
+  loading: () => <TabSkeleton />,
+});
+```
+
+Priority candidates for dynamic imports:
+- `/design-system` — multiple heavy tab components
+- `/media` — Cloudinary image gallery
+- `/photos` — Cloudinary image gallery
+- `/chatroom` — real-time chat dependencies
+
+## CRT Overlay Performance
+
+The CRT scanline/filter overlay uses an SVG filter that is expensive to render, especially on mobile devices and low-powered hardware.
+
+### Current Issue
+
+The CRT overlay applies to the entire viewport on all devices, causing:
+- Dropped frames on mobile
+- High GPU usage on low-end devices
+- Battery drain
+
+### Recommended Fix
+
+Disable the CRT filter on mobile via CSS rather than JavaScript to avoid layout shift:
+
+```css
+/* CRTOverlay.module.css */
+.overlay {
+  /* existing CRT styles */
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    display: none;
+  }
+}
+```
+
+Or reduce the effect intensity on mobile instead of removing it entirely:
+
+```css
+@media (max-width: 768px) {
+  .overlay {
+    opacity: 0.3;
+    /* disable the expensive SVG filter, keep just the scanlines */
+    filter: none;
+  }
+}
+```
+
+## Image Optimization
+
+The site already uses `next-cloudinary` (`CldImage`) for photos and media, which handles optimization well. For any remaining standard images:
+
+- Use `next/image` for local assets that need sizing/format optimization
+- Add `loading="lazy"` to below-the-fold images (Next.js Image does this by default)
+- Use `priority` prop on above-the-fold hero images
+
+## Bundle Analysis
+
+Run the Next.js bundle analyzer periodically to catch regressions:
+
+```bash
+npm install --save-dev @next/bundle-analyzer
+```
+
+```js
+// next.config.js
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
+
+module.exports = withBundleAnalyzer(nextConfig);
+```
+
+```bash
+ANALYZE=true npm run build
+```

--- a/docs/server-components-first.md
+++ b/docs/server-components-first.md
@@ -1,0 +1,90 @@
+# Server Components by Default
+
+## Problem
+
+Every page in the codebase is a client component (`'use client'`), even when most of the page content is static. This forces workarounds like creating separate `layout.tsx` files just to export metadata, increases JavaScript bundle sizes, and prevents leveraging server-side data fetching.
+
+## Recommendation
+
+Pages should be **server components** by default. Extract only the interactive parts into small client components.
+
+### Current Pattern (avoid)
+
+```tsx
+// src/app/about/page.tsx
+'use client';
+
+import { useAudioManager } from '../../hooks/useAudioManager';
+import PageLayout from '../../components/PageLayout/PageLayout';
+
+const AboutPage = () => {
+  const { playSound } = useAudioManager();
+  // entire page is client-rendered
+  return (
+    <PageLayout title="About">
+      <PageLayout.Header />
+      <PageLayout.Body>
+        <p>Static content that doesn't need JS...</p>
+        <button onClick={() => playSound('click')}>Interactive part</button>
+      </PageLayout.Body>
+    </PageLayout>
+  );
+};
+```
+
+### Recommended Pattern
+
+```tsx
+// src/app/about/page.tsx (server component — no 'use client')
+import type { Metadata } from 'next';
+import PageLayout from '../../components/PageLayout/PageLayout';
+import { SoundButton } from './SoundButton'; // small client component
+
+export const metadata: Metadata = {
+  title: 'About',
+  description: 'Learn about Soros Febriano...',
+};
+
+export default function AboutPage() {
+  return (
+    <PageLayout title="About">
+      <PageLayout.Header />
+      <PageLayout.Body>
+        <p>Static content rendered on the server — zero JS shipped.</p>
+        <SoundButton />
+      </PageLayout.Body>
+    </PageLayout>
+  );
+}
+```
+
+```tsx
+// src/app/about/SoundButton.tsx
+'use client';
+
+import { useAudioManager } from '../../hooks/useAudioManager';
+
+export function SoundButton() {
+  const { playSound } = useAudioManager();
+  return <button onClick={() => playSound('click')}>Interactive part</button>;
+}
+```
+
+## Benefits
+
+- **Metadata exports** work directly in `page.tsx` — no extra layout files needed
+- **Smaller bundles** — static content isn't wrapped in client-side React
+- **Faster initial load** — HTML is streamed from the server
+- **Data fetching** — can `await` database/API calls directly in the component
+
+## Migration Strategy
+
+1. Start with pages that have minimal interactivity (about, certifications, books)
+2. Identify which components actually need `'use client'` (audio, hover effects, state)
+3. Extract those into leaf client components
+4. Remove `'use client'` from the page and export metadata directly
+5. Delete the now-unnecessary route-level `layout.tsx` metadata files
+
+## Key Constraint
+
+`PageLayout` currently uses `useAudioManager`, making it a client component. To go server-first, `PageLayout` would need to be split: a server wrapper for structure and a client component for the interactive header/close button.

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About",
+  description: "Learn about Soros Febriano — background, interests, and the story behind sorOS.",
+  alternates: { canonical: "/about" },
+  openGraph: { url: "/about" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description: "Articles and thoughts on technology, art, and everything in between by Soros Febriano.",
+  alternates: { canonical: "/blog" },
+  openGraph: { url: "/blog" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "CollectionPage",
+            "name": "Blog — sorOS",
+            "description": "Articles and thoughts on technology, art, and everything in between by Soros Febriano.",
+            "url": "https://www.sorosfebria.co/blog",
+            "author": {
+              "@type": "Person",
+              "name": "Soros Febriano",
+              "url": "https://www.sorosfebria.co",
+            },
+          }),
+        }}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/books/layout.tsx
+++ b/src/app/books/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Books",
+  description: "Books I've read and recommend — a curated reading list by Soros Febriano.",
+  alternates: { canonical: "/books" },
+  openGraph: { url: "/books" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/certifications/layout.tsx
+++ b/src/app/certifications/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Certifications",
+  description: "Professional certifications and credentials earned by Soros Febriano.",
+  alternates: { canonical: "/certifications" },
+  openGraph: { url: "/certifications" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/chatroom/layout.tsx
+++ b/src/app/chatroom/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Chatroom",
+  description: "Join the live chatroom on sorOS — chat with visitors in real time.",
+  alternates: { canonical: "/chatroom" },
+  openGraph: { url: "/chatroom" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/credits-assets/layout.tsx
+++ b/src/app/credits-assets/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Asset Credits",
+  description: "Attribution and credits for assets used throughout the sorOS portfolio site.",
+  alternates: { canonical: "/credits-assets" },
+  openGraph: { url: "/credits-assets" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/credits-tech/layout.tsx
+++ b/src/app/credits-tech/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Tech Credits",
+  description: "Technologies, libraries, and tools powering the sorOS portfolio site.",
+  alternates: { canonical: "/credits-tech" },
+  openGraph: { url: "/credits-tech" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/design-system/layout.tsx
+++ b/src/app/design-system/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Design System",
+  description: "Component library and design system used to build the sorOS portfolio.",
+  alternates: { canonical: "/design-system" },
+  openGraph: { url: "/design-system" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/digital-gems/layout.tsx
+++ b/src/app/digital-gems/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Digital Gems",
+  description: "A curated collection of interesting websites and digital discoveries by Soros Febriano.",
+  alternates: { canonical: "/digital-gems" },
+  openGraph: { url: "/digital-gems" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata, Viewport } from "next";
 import { Roboto } from "next/font/google";
 import Script from "next/script";
 import { VolumeProvider } from "../context/VolumeContext";
@@ -14,6 +15,46 @@ import CRTOverlay from "../components/CRTOverlay/CRTOverlay";
 import ToastContainer from "../components/ToastNotification/ToastContainer";
 import { GlobalWMPPlayer } from "../components/WMPPlayer/GlobalWMPPlayer";
 import "./globals.css";
+
+const siteUrl = "https://www.sorosfebria.co";
+const siteDescription = "Personal website and portfolio of Soros Febriano, a passionate learner about the fusion of technology and art. Explore projects, photos, media and more.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: "sorOS",
+    template: "%s | sorOS",
+  },
+  description: siteDescription,
+  authors: [{ name: "Soros Febriano", url: siteUrl }],
+  icons: {
+    icon: "/favicon.svg",
+    apple: "/favicon.svg",
+  },
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    title: "Soros Febriano",
+    description: siteDescription,
+    url: siteUrl,
+    siteName: "sorOS",
+    images: [{ url: "/assets/images/thumbnail-sorOS.jpg", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Soros Febriano",
+    description: siteDescription,
+    images: ["/assets/images/thumbnail-sorOS.jpg"],
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#1a1a2e",
+};
 
 const inter = Roboto({ weight: "300", subsets: ["latin"] });
 
@@ -34,25 +75,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             strategy="lazyOnload"
           />
         )}
-        <title>sorOS</title>
-        <meta name="description" content="Personal website and portfolio of Soros Febriano, a passionate learner about the fusion of technology and art. Explore projects, photos, media and more." />
-        {/* Open Graph tags */}
-        <meta property="og:type" content="website" />
-        <meta property="og:title" content="Soros Febriano" />
-        <meta property="og:description" content="Personal website and portfolio of Soros Febriano, a passionate learner about the fusion of technology and art. Explore projects, photos, media and more." />
-        <meta property="og:image" content="https://www.sorosfebria.co/assets/images/thumbnail-sorOS.jpg" />
-        <meta property="og:url" content="https://www.sorosfebria.co/" />
-        {/* Twitter Card tags */}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="Soros Febriano" />
-        <meta name="twitter:description" content="Personal website and portfolio of Soros Febriano, a passionate learner about the fusion of technology and art. Explore projects, photos, media and more." />
-        <meta name="twitter:image" content="https://www.sorosfebria.co/assets/images/thumbnail-sorOS.jpg" />
-        <link rel="icon" href="/favicon.svg" />
+        {/* Title, description, OG, Twitter, favicon & viewport now handled by the Metadata API above. */}
         <link rel="preconnect" href="https://mosaic.scdn.co" />
         <link rel="preconnect" href="https://i.scdn.co" />
         <link rel="dns-prefetch" href="https://img.shields.io" />
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/app/leetcode/layout.tsx
+++ b/src/app/leetcode/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "LeetCode",
+  description: "LeetCode problem-solving progress and statistics by Soros Febriano.",
+  alternates: { canonical: "/leetcode" },
+  openGraph: { url: "/leetcode" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/media/layout.tsx
+++ b/src/app/media/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Media",
+  description: "Videos, recordings, and media content by Soros Febriano.",
+  alternates: { canonical: "/media" },
+  openGraph: { url: "/media" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/music/layout.tsx
+++ b/src/app/music/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Music",
+  description: "What I'm listening to — music taste and currently playing tracks.",
+  alternates: { canonical: "/music" },
+  openGraph: { url: "/music" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/my-playlists/layout.tsx
+++ b/src/app/my-playlists/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "My Playlists",
+  description: "Curated Spotify playlists by Soros Febriano — discover new music.",
+  alternates: { canonical: "/my-playlists" },
+  openGraph: { url: "/my-playlists" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/photos/layout.tsx
+++ b/src/app/photos/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Photos",
+  description: "Photography gallery by Soros Febriano — capturing moments through the lens.",
+  alternates: { canonical: "/photos" },
+  openGraph: { url: "/photos" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Profile",
+  description: "Soros Febriano's profile — skills, experience, and contact information.",
+  alternates: { canonical: "/profile" },
+  openGraph: { url: "/profile" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Projects",
+  description: "Portfolio of software projects and creative work by Soros Febriano.",
+  alternates: { canonical: "/projects" },
+  openGraph: { url: "/projects" },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/toast-demo/layout.tsx
+++ b/src/app/toast-demo/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Toast Demo",
+  robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- Rebases the stale `feat/seo-metadata-api` branch (was 39 commits behind) cleanly onto current `dev`.
- Migrates the root layout from manual `<head>` tags to the **Next.js Metadata API**, and adds page-level metadata to the route tree.
- Implements **SOR-14** (`alternates.canonical`) and **SOR-5** (Metadata API migration).

## Changes
- `src/app/layout.tsx`: `export const metadata` (metadataBase, title template, description, canonical, OpenGraph, Twitter, icons) + `export const viewport` (themeColor moved here per Next 15).
- Per-route `layout.tsx` metadata across ~16 routes.
- `docs/`: architecture improvement guides.

## Conflict resolution (root layout)
Only `src/app/layout.tsx` conflicted (WMP work on `dev` touched it). Resolved by keeping **dev's** provider tree, the **dev-only react-grab `<Script>`s**, and the **resource hints** (`preconnect` scdn.co, `dns-prefetch` shields.io), while adopting the branch's Metadata API. Manual `<title>`/description/OG/Twitter/favicon/charset/viewport tags removed (now provided by the Metadata API).

## Verification
- `npm run compile` (tsc) passes.

## Follow-ups (not in this PR)
- The `/card` route added on `dev` after this branch was cut has **no metadata layout yet** — add one in a follow-up.
- Confirm the OG image path (`/assets/images/thumbnail-sorOS.jpg`) resolves via `metadataBase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)