### PR TITLE
chore(dev): add react-scan render profiler (dev-only)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,6 +63,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <head>
         {process.env.NODE_ENV === "development" && (
+          <script src="https://unpkg.com/react-scan/dist/auto.global.js" crossOrigin="anonymous" />
+        )}
+        {process.env.NODE_ENV === "development" && (
           <Script
             src="//unpkg.com/react-grab/dist/index.global.js"
             crossOrigin="anonymous"


### PR DESCRIPTION
## Summary
- Ran `npx react-scan@latest init` (detected Next.js App Router). It proposed a single dev-only change to `src/app/layout.tsx`, applied here.
- Adds the react-scan auto script into `<head>`, gated on `NODE_ENV === "development"`, loaded **before** the other dev scripts so it instruments renders from the start.

## Changes
- `src/app/layout.tsx` (+3): dev-only `<script src="https://unpkg.com/react-scan/dist/auto.global.js" crossOrigin="anonymous" />`.
- **No dependency added** — the script is CDN-loaded (unpkg) and only in dev, so `package.json` is untouched.

## Verification
- Change is isolated (3 lines); `tsc` raises no error on `layout.tsx`.

## ⚠️ Pre-existing issue (NOT introduced by this PR)
`npm run compile` currently fails on `dev` with 11 errors that exist **before** this change (verified against clean `dev`):
- `@prisma/client` has no `PrismaClient` / `Prisma` exports → the generated Prisma client is stale/missing in `node_modules` (needs `prisma generate`), cascading into `lastfm.ts`, `userService.ts`, `db.ts`.
- A few genuine implicit-`any` / `unknown` type issues (e.g. `ChatRoom.tsx:117`, `userService.ts:53/56`).

These should be fixed separately (regenerate Prisma client + tighten the `any`/`unknown` sites). Flagging so CI/QA doesn't attribute them to react-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)