### PR TITLE
chore: remove in-repo react-scan (use CLI instead)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,9 +63,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <head>
         {process.env.NODE_ENV === "development" && (
-          <script src="https://unpkg.com/react-scan/dist/auto.global.js" crossOrigin="anonymous" />
-        )}
-        {process.env.NODE_ENV === "development" && (
           <Script
             src="//unpkg.com/react-grab/dist/index.global.js"
             crossOrigin="anonymous"


### PR DESCRIPTION
## Summary
Reverts the react-scan CDN `<script>` added in #11. We're standardizing on the **react-scan CLI** instead of any in-repo integration.

## Why
- `npx react-scan@latest http://localhost:3000` gives the same render profiler with **zero repo footprint**, **no prod-leak risk**, and no unpinned unpkg CDN dependency at runtime.
- Profiling is occasional and the dev server is already running for QA, so a committed integration isn't warranted.

## Changes
- `src/app/layout.tsx` (−3): removes the dev-only react-scan script tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)