### PR TITLE
feat(wmp): full-length YouTube playback in the WMP skin

### DIFF
--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -11,16 +11,22 @@ const MusicPage = () => {
   const { openWithPlaylist, currentPlaylist } = useWMPPlayerContext();
 
   const { data: catalog, isLoading } = trpc.audio.getCatalog.useQuery();
+  const { data: youtubeAlbum } = trpc.audio.getYouTubePlaylist.useQuery();
 
-  // effect:audited — auto-load the default catalog into the player on first
-  // visit so the page demonstrates a working player rather than an empty UI.
-  // Guarded so we don't trample a playlist the user already loaded elsewhere.
+  // effect:audited — auto-load a playlist into the player on first visit so the
+  // page demonstrates a working player rather than an empty UI. Prefers the
+  // curated YouTube album (full-length streaming, no login); falls back to the
+  // self-hosted audio catalog. Guarded so we don't trample a playlist the user
+  // already loaded elsewhere.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => {
-    if (catalog && catalog.length > 0 && currentPlaylist.length === 0) {
+    if (currentPlaylist.length > 0) return;
+    if (youtubeAlbum && youtubeAlbum.length > 0) {
+      openWithPlaylist(youtubeAlbum);
+    } else if (catalog && catalog.length > 0) {
       openWithPlaylist(catalog);
     }
-  }, [catalog]);
+  }, [catalog, youtubeAlbum]);
 
   return (
     <PageLayout title="Music">

--- a/src/hooks/useWMPPlayer.ts
+++ b/src/hooks/useWMPPlayer.ts
@@ -12,6 +12,7 @@ import type {
   WMPPlayerAction,
 } from '@/types/wmp';
 import { useVolume } from '@/context/VolumeContext';
+import { YouTubeEngine } from '@/lib/wmp/youtubeEngine';
 
 // Helper to format time in M:SS format
 function formatTime(seconds: number): string {
@@ -251,6 +252,11 @@ function playerReducer(
 export function useWMPPlayer() {
   const [state, dispatch] = useReducer(playerReducer, initialState);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const youtubeEngineRef = useRef<YouTubeEngine | null>(null);
+  // Mirror the current track into a ref so effects/callbacks that must not
+  // re-subscribe on every track change can still read the latest source.
+  const currentTrackRef = useRef<Track | null>(null);
+  currentTrackRef.current = state.currentTrack;
   const { volume: globalVolume } = useVolume();
 
   // Initialize audio element
@@ -309,49 +315,107 @@ export function useWMPPlayer() {
     };
   }, []);
 
-  // Sync volume with global volume context and player state
+  // Initialize the YouTube engine. Headless and self-mounting (like the <audio>
+  // element above), it drives `source: 'youtube'` tracks and reports playback
+  // progress/lifecycle back into the reducer.
   useEffect(() => {
-    if (!audioRef.current) return;
+    if (typeof window === 'undefined') return;
 
-    // Use player state volume, but scale by global volume
+    const engine = new YouTubeEngine({
+      onTime: (time) => dispatch({ type: 'UPDATE_TIME', time }),
+      onDuration: (duration) => dispatch({ type: 'UPDATE_DURATION', duration }),
+      onEnded: () => dispatch({ type: 'TRACK_ENDED' }),
+      onLoadingChange: (isLoading) => dispatch({ type: 'SET_LOADING', isLoading }),
+      onError: (error) => dispatch({ type: 'SET_ERROR', error }),
+    });
+    youtubeEngineRef.current = engine;
+    engine.init();
+
+    return () => {
+      engine.destroy();
+      youtubeEngineRef.current = null;
+    };
+  }, []);
+
+  // Sync volume with the global volume context, scaled into each engine's range.
+  useEffect(() => {
     const effectiveVolume = (state.volume / 100) * (globalVolume / 100);
-    audioRef.current.volume = state.muted ? 0 : effectiveVolume;
+    const gain = state.muted ? 0 : effectiveVolume;
+
+    if (audioRef.current) {
+      audioRef.current.volume = gain; // HTMLAudioElement: 0-1
+    }
+    youtubeEngineRef.current?.setVolume(gain * 100); // YouTube: 0-100
   }, [state.volume, state.muted, globalVolume]);
 
-  // Handle track changes — only the <audio>-backed variant drives audioRef.
-  // The Spotify embed engine renders its own iframe at the component level.
+  // Handle track changes. Each backend acts only for its own `source`; the
+  // others are told to stand down so two engines never play at once. The
+  // Spotify embed engine renders its own iframe at the component level.
   useEffect(() => {
-    if (!audioRef.current || !state.currentTrack) return;
-
     const audio = audioRef.current;
+    const youtube = youtubeEngineRef.current;
+    const track = state.currentTrack;
 
-    if (state.currentTrack.source !== 'audio') {
-      audio.pause();
-      audio.src = '';
+    if (!track) {
+      audio?.pause();
+      if (audio) audio.src = '';
+      youtube?.stop();
       return;
     }
 
-    audio.src = state.currentTrack.url;
-
-    if (state.isPlaying) {
-      audio.play().catch((error) => {
-        console.error('Failed to play audio:', error);
-        dispatch({ type: 'SET_ERROR', error: 'Failed to play audio' });
-      });
+    if (track.source === 'audio') {
+      youtube?.stop();
+      if (audio) {
+        audio.src = track.url;
+        if (state.isPlaying) {
+          audio
+            .play()
+            .catch(() =>
+              dispatch({ type: 'SET_ERROR', error: 'Failed to play audio' })
+            );
+        }
+      }
+      return;
     }
+
+    if (track.source === 'youtube') {
+      if (audio) {
+        audio.pause();
+        audio.src = '';
+      }
+      youtube?.load(track.youtubeVideoId, { autoplay: state.isPlaying });
+      return;
+    }
+
+    // spotify-embed (and any future embed): silence the imperative engines and
+    // let the embed component own playback.
+    if (audio) {
+      audio.pause();
+      audio.src = '';
+    }
+    youtube?.stop();
   }, [state.currentTrack]);
 
-  // Handle play/pause state changes
+  // Handle play/pause state changes for whichever engine owns the current track.
   useEffect(() => {
-    if (!audioRef.current) return;
+    const shouldPlay = state.isPlaying && !state.isPaused;
+
+    if (currentTrackRef.current?.source === 'youtube') {
+      const youtube = youtubeEngineRef.current;
+      if (shouldPlay) youtube?.play();
+      else youtube?.pause();
+      return;
+    }
 
     const audio = audioRef.current;
+    if (!audio) return;
 
-    if (state.isPlaying && !state.isPaused) {
-      audio.play().catch((error) => {
-        console.error('Failed to play audio:', error);
-        dispatch({ type: 'SET_ERROR', error: 'Failed to play audio' });
-      });
+    if (shouldPlay) {
+      audio
+        .play()
+        .catch(() =>
+          dispatch({ type: 'SET_ERROR', error: 'Failed to play audio' })
+        );
     } else {
       audio.pause();
     }
@@ -377,6 +441,7 @@ export function useWMPPlayer() {
     if (audioRef.current) {
       audioRef.current.currentTime = 0;
     }
+    youtubeEngineRef.current?.stop();
   }, []);
 
   const next = useCallback(() => {
@@ -388,7 +453,9 @@ export function useWMPPlayer() {
   }, []);
 
   const seek = useCallback((time: number) => {
-    if (audioRef.current) {
+    if (currentTrackRef.current?.source === 'youtube') {
+      youtubeEngineRef.current?.seek(time);
+    } else if (audioRef.current) {
       audioRef.current.currentTime = time;
     }
     dispatch({ type: 'SEEK', time });

--- a/src/lib/wmp/youtubeEngine.ts
+++ b/src/lib/wmp/youtubeEngine.ts
@@ -1,0 +1,339 @@
+/**
+ * Framework-agnostic wrapper around the YouTube IFrame Player API, so the WMP
+ * player can drive YouTube as a headless audio backend. It exposes the same
+ * imperative surface as an HTMLAudioElement (load / play / pause / seek /
+ * volume) plus a set of callbacks, letting `useWMPPlayer` treat YouTube exactly
+ * like the `<audio>` element it already manages.
+ *
+ * The engine owns a hidden container appended to <body>. YouTube refuses to
+ * play when the player is `display: none`, so the container is positioned
+ * offscreen (present in the DOM, visually gone) rather than hidden outright.
+ *
+ * Only the slice of the IFrame API we use is typed below, which avoids taking
+ * on a `@types/youtube` dependency.
+ */
+
+interface YTPlayerVars {
+  autoplay?: 0 | 1;
+  controls?: 0 | 1;
+  disablekb?: 0 | 1;
+  modestbranding?: 0 | 1;
+  rel?: 0 | 1;
+  playsinline?: 0 | 1;
+  iv_load_policy?: 1 | 3;
+  origin?: string;
+}
+
+interface YTPlayerEvent {
+  target: YTPlayer;
+  data: number;
+}
+
+interface YTPlayer {
+  playVideo(): void;
+  pauseVideo(): void;
+  stopVideo(): void;
+  seekTo(seconds: number, allowSeekAhead: boolean): void;
+  setVolume(volume: number): void;
+  loadVideoById(videoId: string): void;
+  cueVideoById(videoId: string): void;
+  getCurrentTime(): number;
+  getDuration(): number;
+  destroy(): void;
+}
+
+interface YTNamespace {
+  Player: new (
+    el: HTMLElement | string,
+    opts: {
+      width?: string | number;
+      height?: string | number;
+      videoId?: string;
+      playerVars?: YTPlayerVars;
+      events?: {
+        onReady?: (event: YTPlayerEvent) => void;
+        onStateChange?: (event: YTPlayerEvent) => void;
+        onError?: (event: YTPlayerEvent) => void;
+      };
+    }
+  ) => YTPlayer;
+  PlayerState: {
+    UNSTARTED: -1;
+    ENDED: 0;
+    PLAYING: 1;
+    PAUSED: 2;
+    BUFFERING: 3;
+    CUED: 5;
+  };
+}
+
+declare global {
+  interface Window {
+    YT?: YTNamespace;
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}
+
+const IFRAME_API_SRC = 'https://www.youtube.com/iframe_api';
+
+/** Progress poll cadence while playing (ms). Matches WMP's ~1/sec LCD needs. */
+const POLL_INTERVAL_MS = 250;
+
+let apiPromise: Promise<YTNamespace> | null = null;
+
+/**
+ * Load the IFrame API exactly once. Chains any pre-existing
+ * `onYouTubeIframeAPIReady` so we don't clobber another consumer.
+ */
+function loadIframeApi(): Promise<YTNamespace> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('YouTube IFrame API requires a browser'));
+  }
+  if (window.YT?.Player) {
+    return Promise.resolve(window.YT);
+  }
+  if (apiPromise) return apiPromise;
+
+  apiPromise = new Promise<YTNamespace>((resolve) => {
+    const previous = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      previous?.();
+      if (window.YT) resolve(window.YT);
+    };
+
+    // Reuse an existing tag if the script is already in flight.
+    const existing = document.querySelector(
+      `script[src="${IFRAME_API_SRC}"]`
+    );
+    if (!existing) {
+      const tag = document.createElement('script');
+      tag.src = IFRAME_API_SRC;
+      document.head.appendChild(tag);
+    }
+  });
+
+  return apiPromise;
+}
+
+export interface YouTubeEngineCallbacks {
+  /** Fired ~4x/sec while playing with the current position in seconds. */
+  onTime?: (seconds: number) => void;
+  /** Fired once per track when the duration becomes known. */
+  onDuration?: (seconds: number) => void;
+  /** Fired when the video reaches its end. */
+  onEnded?: () => void;
+  /** Buffering (true) / ready-to-play (false). */
+  onLoadingChange?: (loading: boolean) => void;
+  /** A playback/network error occurred. */
+  onError?: (message: string) => void;
+}
+
+/**
+ * Imperative YouTube playback engine. One instance per WMP player; reused
+ * across tracks via {@link load}.
+ */
+export class YouTubeEngine {
+  private readonly container: HTMLDivElement;
+  private readonly mountEl: HTMLDivElement;
+  private player: YTPlayer | null = null;
+  private ready = false;
+  private destroyed = false;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private pending: { videoId: string; autoplay: boolean } | null = null;
+  private currentVideoId: string | null = null;
+  private lastDuration = 0;
+  private pendingVolume: number | null = null;
+
+  constructor(private readonly callbacks: YouTubeEngineCallbacks) {
+    this.container = document.createElement('div');
+    Object.assign(this.container.style, {
+      position: 'fixed',
+      left: '-10000px',
+      top: '0px',
+      width: '200px',
+      height: '200px',
+      opacity: '0',
+      pointerEvents: 'none',
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.container.setAttribute('aria-hidden', 'true');
+
+    // YT replaces the passed element with the iframe, so mount on a child.
+    this.mountEl = document.createElement('div');
+    this.container.appendChild(this.mountEl);
+    document.body.appendChild(this.container);
+  }
+
+  /** Load the IFrame API and instantiate the underlying player. */
+  async init(): Promise<void> {
+    let YT: YTNamespace;
+    try {
+      YT = await loadIframeApi();
+    } catch {
+      this.callbacks.onError?.('Failed to load the YouTube player');
+      return;
+    }
+    if (this.destroyed) return;
+
+    this.player = new YT.Player(this.mountEl, {
+      width: 200,
+      height: 200,
+      playerVars: {
+        autoplay: 0,
+        controls: 0,
+        disablekb: 1,
+        modestbranding: 1,
+        rel: 0,
+        playsinline: 1,
+        iv_load_policy: 3,
+        origin: window.location.origin,
+      },
+      events: {
+        onReady: this.handleReady,
+        onStateChange: this.handleStateChange,
+        onError: this.handleError,
+      },
+    });
+  }
+
+  private handleReady = () => {
+    this.ready = true;
+    if (this.pendingVolume !== null) {
+      this.player?.setVolume(this.pendingVolume);
+      this.pendingVolume = null;
+    }
+    if (this.pending) {
+      const { videoId, autoplay } = this.pending;
+      this.pending = null;
+      this.load(videoId, { autoplay });
+    }
+  };
+
+  private handleStateChange = (event: YTPlayerEvent) => {
+    const state = event.data;
+    switch (state) {
+      case 1: // PLAYING
+        this.callbacks.onLoadingChange?.(false);
+        this.emitDuration();
+        this.startPolling();
+        break;
+      case 2: // PAUSED
+        this.stopPolling();
+        break;
+      case 0: // ENDED
+        this.stopPolling();
+        this.callbacks.onEnded?.();
+        break;
+      case 3: // BUFFERING
+        this.callbacks.onLoadingChange?.(true);
+        break;
+      case 5: // CUED
+        this.callbacks.onLoadingChange?.(false);
+        this.emitDuration();
+        break;
+      default:
+        break;
+    }
+  };
+
+  private handleError = () => {
+    this.stopPolling();
+    this.callbacks.onError?.('YouTube could not play this track');
+  };
+
+  private emitDuration() {
+    if (!this.player) return;
+    const duration = this.player.getDuration();
+    if (duration && duration !== this.lastDuration) {
+      this.lastDuration = duration;
+      this.callbacks.onDuration?.(duration);
+    }
+  }
+
+  private startPolling() {
+    if (this.pollTimer !== null) return;
+    this.pollTimer = setInterval(() => {
+      if (!this.player) return;
+      this.callbacks.onTime?.(this.player.getCurrentTime());
+      this.emitDuration();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private stopPolling() {
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  /** Cue or play a video. Safe to call before the player is ready. */
+  load(videoId: string, { autoplay }: { autoplay: boolean }): void {
+    this.currentVideoId = videoId;
+    this.lastDuration = 0;
+    if (!this.ready || !this.player) {
+      this.pending = { videoId, autoplay };
+      return;
+    }
+    if (autoplay) {
+      this.player.loadVideoById(videoId);
+    } else {
+      this.player.cueVideoById(videoId);
+    }
+  }
+
+  play(): void {
+    if (!this.ready || !this.player) {
+      if (this.pending) this.pending.autoplay = true;
+      return;
+    }
+    this.player.playVideo();
+  }
+
+  pause(): void {
+    if (!this.ready || !this.player) {
+      if (this.pending) this.pending.autoplay = false;
+      return;
+    }
+    this.player.pauseVideo();
+  }
+
+  /** Pause and rewind to the start (WMP "stop"). */
+  stop(): void {
+    this.stopPolling();
+    if (this.ready && this.player) {
+      this.player.pauseVideo();
+      this.player.seekTo(0, true);
+    }
+  }
+
+  seek(seconds: number): void {
+    if (this.ready && this.player) {
+      this.player.seekTo(seconds, true);
+    }
+  }
+
+  /** @param volume 0-100 (YouTube's native range). */
+  setVolume(volume: number): void {
+    const clamped = Math.max(0, Math.min(100, Math.round(volume)));
+    if (this.ready && this.player) {
+      this.player.setVolume(clamped);
+    } else {
+      this.pendingVolume = clamped;
+    }
+  }
+
+  getCurrentVideoId(): string | null {
+    return this.currentVideoId;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.stopPolling();
+    try {
+      this.player?.destroy();
+    } catch {
+      // Player may already be torn down; ignore.
+    }
+    this.player = null;
+    this.container.remove();
+  }
+}

--- a/src/server/data/youtubePlaylist.ts
+++ b/src/server/data/youtubePlaylist.ts
@@ -1,0 +1,49 @@
+import type { YouTubeTrack } from '@/types/wmp';
+
+/**
+ * Curated "featured album" the WMP player streams full-length through the
+ * YouTube engine (`src/lib/wmp/youtubeEngine.ts`). This mirrors how ryOS builds
+ * its iPod library: each entry is a hand-picked YouTube video id, so playback
+ * works for every visitor with no login, no subscription, and no API quota.
+ *
+ * Each entry must satisfy the YouTubeTrack contract from `src/types/wmp.ts`:
+ *   - `source: 'youtube'`
+ *   - `youtubeVideoId`: the 11-char id from a watch URL
+ *       (https://www.youtube.com/watch?v=<ID>  ->  <ID>)
+ *   - `imageUrl` (optional): any cover art. YouTube thumbnails
+ *       (https://i.ytimg.com/vi/<ID>/hqdefault.jpg) always work.
+ *   - `spotifyUrl` (optional): deep-link back to the track on Spotify
+ *
+ * NOTE: the entries below are PLACEHOLDERS so the player is testable out of the
+ * box. Replace them with your Spotify album's tracks. If a track shows "Video
+ * unavailable", that upload has embedding disabled — pick a different upload of
+ * the same song.
+ */
+const ytThumb = (id: string) => `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
+
+export const youtubePlaylist: YouTubeTrack[] = [
+  {
+    source: 'youtube',
+    id: 'yt-dQw4w9WgXcQ',
+    name: 'Never Gonna Give You Up',
+    artist: 'Rick Astley',
+    youtubeVideoId: 'dQw4w9WgXcQ',
+    imageUrl: ytThumb('dQw4w9WgXcQ'),
+  },
+  {
+    source: 'youtube',
+    id: 'yt-9bZkp7q19f0',
+    name: 'Gangnam Style',
+    artist: 'PSY',
+    youtubeVideoId: '9bZkp7q19f0',
+    imageUrl: ytThumb('9bZkp7q19f0'),
+  },
+  {
+    source: 'youtube',
+    id: 'yt-kJQP7kiw5Fk',
+    name: 'Despacito',
+    artist: 'Luis Fonsi ft. Daddy Yankee',
+    youtubeVideoId: 'kJQP7kiw5Fk',
+    imageUrl: ytThumb('kJQP7kiw5Fk'),
+  },
+];

--- a/src/server/routers/audio.ts
+++ b/src/server/routers/audio.ts
@@ -1,11 +1,14 @@
 import { createTRPCRouter, publicProcedure } from '../trpc';
 import { audioCatalog } from '../data/audioCatalog';
+import { youtubePlaylist } from '../data/youtubePlaylist';
 
 /**
- * Serves self-hosted audio tracks that the WMP player streams through its
- * HTMLAudioElement engine. Edit `src/server/data/audioCatalog.ts` to change
- * the default playlist.
+ * Serves playlists that the WMP player streams. `getCatalog` returns
+ * self-hosted tracks (HTMLAudioElement engine); `getYouTubePlaylist` returns a
+ * curated album streamed full-length through the YouTube engine. Edit the data
+ * files under `src/server/data/` to change either playlist.
  */
 export const audioRouter = createTRPCRouter({
   getCatalog: publicProcedure.query(() => audioCatalog),
+  getYouTubePlaylist: publicProcedure.query(() => youtubePlaylist),
 });

--- a/src/types/wmp.ts
+++ b/src/types/wmp.ts
@@ -169,7 +169,20 @@ export interface SpotifyEmbedTrack extends BaseTrack {
   spotifyUrl: string;     // Canonical https://open.spotify.com/track/{id} link
 }
 
-export type Track = AudioTrack | SpotifyEmbedTrack;
+/**
+ * Plays via the YouTube IFrame Player API engine (`src/lib/wmp/youtubeEngine.ts`).
+ * YouTube is the audio backend: the video surface is mounted hidden and WMP
+ * transport drives playback programmatically (play/pause/seek/volume/ended),
+ * unlike the Spotify embed which owns its own transport. Gives full-length
+ * playback for every visitor with no login.
+ */
+export interface YouTubeTrack extends BaseTrack {
+  source: 'youtube';
+  youtubeVideoId: string; // 11-char YouTube video id
+  spotifyUrl?: string;    // Optional deep-link back to the original Spotify track
+}
+
+export type Track = AudioTrack | SpotifyEmbedTrack | YouTubeTrack;
 
 export interface Playlist {
   id: string;


### PR DESCRIPTION
## Summary
- Lets the WMP-skinned player stream **full-length** tracks for **every visitor, with no login or subscription** — the only combination that satisfies "my album · full songs · anonymous visitors · fully-skinned player".
- Uses the **YouTube IFrame Player API** as a headless audio backend, driven entirely by the existing WMP skin. Data path is **curated video ids** (mirrors ryOS's iPod library) — no API key, no DB, no quota.

## Changes
- `src/types/wmp.ts` — add `YouTubeTrack` (`source: 'youtube'`) to the `Track` discriminated union.
- `src/lib/wmp/youtubeEngine.ts` — framework-agnostic YouTube IFrame wrapper (load/play/pause/seek/volume + time/duration/ended callbacks; self-mounts a hidden offscreen container since YouTube won't play under `display:none`).
- `src/hooks/useWMPPlayer.ts` — drive the YouTube engine alongside the existing `<audio>` element; each backend acts only for its own track `source`; volume flows through `VolumeContext`.
- `src/server/data/youtubePlaylist.ts` + `audio.getYouTubePlaylist` — curated album served over tRPC.
- `src/app/music/page.tsx` — prefer the YouTube album, fall back to the self-hosted audio catalog.

## Test Plan
1. Run dev, open `/music`.
2. The WMP player opens on the curated album and plays **full-length** (placeholder tracks: Rick Astley / PSY / Luis Fonsi).
3. Verify transport (play/pause/next/prev), seek, and volume all drive the hidden YouTube player, with no third-party player chrome visible.
4. `npm run compile` is clean for all changed files.

## Notes / accepted trade-offs
- Uses the hidden-player pattern (same as ryOS) — a known YouTube ToS gray area, accepted for a personal site.
- Possible pre-roll ads; embedding-disabled/region-locked uploads need an alternate video id; iOS needs a tap to start and won't play with the screen locked.

## Follow-ups (not in this PR)
- Replace the 3 placeholder tracks with the real album tracklist.
- Optional: auto-resolve any Spotify playlist → YouTube ids via YouTube Data API v3 + Prisma cache (needs `YOUTUBE_API_KEY` + `db push`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)