### PR TITLE
feat(card): Xbox 360 Profile-screen gamercard pilot route

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -14,6 +14,7 @@ module.exports = {
   exclude: [
     '/api/*',
     '/404',
+    '/card-pilot',
   ],
   additionalPaths: async (config) => {
     return [

--- a/src/app/card-pilot/layout.tsx
+++ b/src/app/card-pilot/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Card Pilot",
+  description: "Design pilot for the Gamercard business card.",
+  // Development pilot — keep out of search indexes
+  robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/card-pilot/page.tsx
+++ b/src/app/card-pilot/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import React from 'react';
+import GamerCard from '../../components/GamerCard';
+
+/**
+ * Pilot route for the /card Gamercard redesign.
+ * Once approved, GamerCard replaces the content of /card and this route is removed.
+ */
+const CardPilotPage: React.FC = () => {
+  return <GamerCard />;
+};
+
+export default CardPilotPage;

--- a/src/components/GamerCard/GamerCard.module.css
+++ b/src/components/GamerCard/GamerCard.module.css
@@ -1,0 +1,242 @@
+.page {
+  position: relative;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background:
+    radial-gradient(ellipse at 25% 12%, hsl(95 28% 15% / 0.9), transparent 60%),
+    radial-gradient(ellipse at 80% 95%, hsl(95 22% 10% / 0.8), transparent 55%),
+    hsl(0 0% 5%);
+  color: var(--color-text-primary);
+  font-family: var(--font-primary);
+  overflow-x: hidden;
+}
+
+/* ============ Chrome: title / gamerpic / clock ============ */
+
+.chrome {
+  position: relative;
+  width: min(1100px, 100%);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--spacing-2);
+}
+
+.chromeTitle {
+  margin: 0;
+  font-size: 20px;
+  font-weight: var(--font-weight-semibold);
+  color: #ffffff;
+  text-shadow: var(--shadow-text);
+}
+
+.chromeAvatar {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 44px;
+  height: 44px;
+  border: 2px solid hsl(0 0% 40%);
+  border-radius: var(--radius-sm);
+  background: hsl(0 0% 13%);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.chromeAvatarImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+}
+
+.chromeClock {
+  font-size: 14px;
+  color: #cccccc;
+}
+
+/* ============ The main panel ============ */
+
+.panel {
+  width: min(1100px, 100%);
+  height: clamp(420px, 72vh, 620px);
+  display: flex;
+  background: var(--gradient-metallic);
+  border: var(--border-width-medium) solid var(--color-border-secondary);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    var(--shadow-xl),
+    0 0 0 1px hsl(0 0% 100% / 0.05),
+    inset 0 1px 0 hsl(0 0% 100% / 0.08);
+  overflow: hidden;
+}
+
+.menuColumn {
+  width: 38%;
+  min-width: 250px;
+  max-width: 380px;
+  border-right: 1px solid var(--color-border-primary);
+  background: hsl(0 0% 100% / 0.02);
+  overflow-y: auto;
+}
+
+.rightPane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.identitySection {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--color-border-primary);
+  background: hsl(0 0% 0% / 0.15);
+}
+
+.paneViewport {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.section {
+  scroll-margin-top: var(--spacing-3);
+}
+
+/* Desktop: only the menu-selected pane is visible; switching
+   replays the slide-in like the console swapping panels. */
+@media (min-width: 769px) {
+  .section {
+    display: none;
+  }
+
+  .sectionActive {
+    display: block;
+    animation: paneIn var(--duration-slow) var(--ease-smooth);
+  }
+}
+
+@keyframes paneIn {
+  from {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* ============ Footer: Ⓐ Select / Ⓑ Back ============ */
+
+.chromeFooter {
+  width: min(1100px, 100%);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  padding: 0 var(--spacing-2);
+}
+
+.controlButton {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--ease-smooth);
+}
+
+.controlButton:hover {
+  background-color: hsl(0 0% 100% / 0.1);
+}
+
+.buttonIcon {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  font-weight: var(--font-weight-bold);
+  transition: transform 0.15s ease;
+}
+
+.buttonIconGreen {
+  background: #00ff00;
+  color: #000000;
+  box-shadow: 0 0 8px rgb(0 255 0 / 30%);
+}
+
+.buttonIconRed {
+  background: #ff0000;
+  color: #000000;
+  box-shadow: 0 0 8px rgb(255 0 0 / 30%);
+}
+
+.controlButton:hover .buttonIcon {
+  transform: scale(1.1);
+}
+
+.buttonText {
+  font-size: 14px;
+  color: #ffffff;
+}
+
+/* ============ Mobile: single scrolling column + tab bar ============ */
+
+@media (max-width: 768px) {
+  .page {
+    justify-content: flex-start;
+    padding: var(--spacing-3);
+    /* Clear the fixed bottom tab bar */
+    padding-bottom: calc(72px + env(safe-area-inset-bottom));
+  }
+
+  .chromeAvatar {
+    display: none;
+  }
+
+  .panel {
+    flex-direction: column;
+    height: auto;
+    overflow: visible;
+  }
+
+  .menuColumn {
+    display: none;
+  }
+
+  .paneViewport {
+    overflow: visible;
+  }
+
+  .section {
+    border-bottom: 1px solid var(--color-border-primary);
+  }
+
+  .section:last-child {
+    border-bottom: none;
+  }
+
+  .chromeFooter {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sectionActive {
+    animation: none;
+  }
+}

--- a/src/components/GamerCard/GamerCard.stories.tsx
+++ b/src/components/GamerCard/GamerCard.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import GamerCard from './GamerCard';
+import { VolumeProvider } from '../../context/VolumeContext';
+import { ToastProvider } from '../../context/ToastContext';
+import ToastContainer from '../ToastNotification/ToastContainer';
+
+const meta: Meta<typeof GamerCard> = {
+  title: 'Xbox Components/GamerCard',
+  component: GamerCard,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Xbox 360 blades-era Profile screen reimagined as a business card: menu-driven two-column layout on desktop, vertically scrollable column with a bottom tab bar on mobile. Content comes from src/data/card.ts; Save Contact downloads a client-generated vCard.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <VolumeProvider>
+        <ToastProvider>
+          <Story />
+          <ToastContainer />
+        </ToastProvider>
+      </VolumeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Full Profile screen. Resize the viewport below 768px to see the
+ * mobile column with the bottom tab bar.
+ */
+export const Default: Story = {};
+
+/**
+ * Mobile viewport preset — vertically scrollable with bottom tabs.
+ */
+export const Mobile: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/src/components/GamerCard/GamerCard.tsx
+++ b/src/components/GamerCard/GamerCard.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { useAudioManager } from '../../hooks/useAudioManager';
+import { useNavigationSound } from '../../hooks/useNavigationSound';
+import { useEventListener, useMountEffect, useScrollSpy } from '@/hooks';
+import { useToast, createSystemToast } from '../ToastNotification';
+import { Clock } from '../ui/Clock/Clock';
+import { downloadVCard } from '../../utils/vcard';
+import { identity } from '../../data/card';
+import type { MenuItem, SectionId } from './sections';
+import { MENU_ITEMS, SECTION_DOM_IDS, sectionDomId } from './sections';
+import MenuList from './MenuList';
+import TabBar from './TabBar';
+import IdentityPanel from './IdentityPanel';
+import ExperiencePane from './panes/ExperiencePane';
+import WorkPane from './panes/WorkPane';
+import SkillsPane from './panes/SkillsPane';
+import ContactPane from './panes/ContactPane';
+import styles from './GamerCard.module.css';
+
+/**
+ * GamerCard — Xbox 360 blades-era Profile screen as a business card.
+ *
+ * Desktop: two-column replica — menu list on the left drives which
+ * content pane shows on the right; Ⓐ/Ⓑ footer and keyboard navigation.
+ * Mobile (≤768px): one vertically scrollable column with a fixed bottom
+ * tab bar; the green indicator tracks the section in view via scroll-spy.
+ */
+const GamerCard: React.FC = () => {
+  const { playSound } = useAudioManager();
+  const { navigateWithSound } = useNavigationSound();
+  const { showToast } = useToast();
+
+  const [cursorIndex, setCursorIndex] = useState(0);
+  const [activeSection, setActiveSection] = useState<SectionId>('experience');
+
+  // Mobile scroll-spy; hidden desktop sections never intersect, so this
+  // only meaningfully updates while the page scrolls on small screens.
+  const spyId = useScrollSpy(SECTION_DOM_IDS);
+  const spySection = (spyId?.replace('gc-', '') ?? 'profile') as SectionId;
+
+  useMountEffect(() => {
+    playSound('panel');
+  });
+
+  const handleCursorChange = (index: number) => {
+    if (index !== cursorIndex) {
+      setCursorIndex(index);
+      playSound('hover');
+    }
+  };
+
+  const handleSaveContact = () => {
+    downloadVCard();
+    playSound('achievement');
+    showToast(createSystemToast('Contact card saved — add it to your contacts', 'success'));
+  };
+
+  const handleBack = () => {
+    navigateWithSound('/', 'back');
+  };
+
+  const activateItem = (item: MenuItem) => {
+    if (item.kind === 'section') {
+      playSound('click');
+      setActiveSection(item.id as SectionId);
+    } else if (item.id === 'save-contact') {
+      handleSaveContact();
+    } else if (item.id === 'dashboard') {
+      navigateWithSound('/', 'navigation');
+    }
+  };
+
+  const handleTabSelect = (id: SectionId) => {
+    playSound('click');
+    const target = document.getElementById(sectionDomId(id));
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    target?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+  };
+
+  // Console-style keyboard control (desktop): ↑/↓ move the selection
+  // bar, Enter activates, Escape backs out to the dashboard.
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (window.innerWidth <= 768) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      handleCursorChange(Math.min(cursorIndex + 1, MENU_ITEMS.length - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      handleCursorChange(Math.max(cursorIndex - 1, 0));
+    } else if (event.key === 'Enter') {
+      // Let focused interactive elements handle Enter themselves
+      const target = event.target as HTMLElement | null;
+      if (target?.closest('button, a, input')) return;
+      activateItem(MENU_ITEMS[cursorIndex]);
+    } else if (event.key === 'Escape') {
+      handleBack();
+    }
+  };
+
+  useEventListener(typeof window === 'undefined' ? null : window, 'keydown', handleKeyDown);
+
+  const sectionClass = (id: SectionId) =>
+    `${styles.section} ${activeSection === id ? styles.sectionActive : ''}`;
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.chrome}>
+        <h1 className={styles.chromeTitle}>Profile</h1>
+        <div className={styles.chromeAvatar} aria-hidden="true">
+          <Image
+            src={identity.avatarSrc}
+            alt=""
+            width={44}
+            height={44}
+            sizes="44px"
+            className={styles.chromeAvatarImage}
+          />
+        </div>
+        <Clock className={styles.chromeClock} />
+      </header>
+
+      <div className={styles.panel}>
+        <div className={styles.menuColumn}>
+          <MenuList
+            items={MENU_ITEMS}
+            cursorIndex={cursorIndex}
+            onCursorChange={handleCursorChange}
+            onActivate={activateItem}
+          />
+        </div>
+
+        <div className={styles.rightPane}>
+          <section id={sectionDomId('profile')} className={styles.identitySection}>
+            <IdentityPanel
+              onSaveContact={handleSaveContact}
+              onHoverSound={() => playSound('hover')}
+            />
+          </section>
+
+          <div className={styles.paneViewport}>
+            <section id={sectionDomId('experience')} className={sectionClass('experience')}>
+              <ExperiencePane />
+            </section>
+            <section id={sectionDomId('work')} className={sectionClass('work')}>
+              <WorkPane />
+            </section>
+            <section id={sectionDomId('skills')} className={sectionClass('skills')}>
+              <SkillsPane />
+            </section>
+            <section id={sectionDomId('contact')} className={sectionClass('contact')}>
+              <ContactPane />
+            </section>
+          </div>
+        </div>
+      </div>
+
+      <footer className={styles.chromeFooter}>
+        <button
+          type="button"
+          className={styles.controlButton}
+          onClick={() => activateItem(MENU_ITEMS[cursorIndex])}
+          onMouseEnter={() => playSound('owawa')}
+        >
+          <span className={`${styles.buttonIcon} ${styles.buttonIconGreen}`}>A</span>
+          <span className={styles.buttonText}>Select</span>
+        </button>
+        <button
+          type="button"
+          className={styles.controlButton}
+          onClick={handleBack}
+          onMouseEnter={() => playSound('owawa')}
+        >
+          <span className={`${styles.buttonIcon} ${styles.buttonIconRed}`}>B</span>
+          <span className={styles.buttonText}>Back</span>
+        </button>
+      </footer>
+
+      <TabBar activeId={spySection} onSelect={handleTabSelect} />
+    </div>
+  );
+};
+
+export default GamerCard;

--- a/src/components/GamerCard/IdentityPanel.module.css
+++ b/src/components/GamerCard/IdentityPanel.module.css
@@ -1,0 +1,181 @@
+.identity {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Gamertag strip — the light bar holding the name, like "Kylirez" */
+.gamertagStrip {
+  padding: var(--spacing-2) var(--spacing-4);
+  background: linear-gradient(180deg, hsl(0 0% 100% / 0.1), hsl(0 0% 100% / 0.05));
+  border-bottom: 1px solid var(--color-border-primary);
+  box-shadow: var(--shadow-inset-light);
+}
+
+.gamertag {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-regular);
+  letter-spacing: var(--letter-spacing-wide);
+  color: var(--color-text-primary);
+  text-shadow: var(--shadow-text);
+}
+
+.body {
+  display: flex;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+}
+
+/* Framed gamerpic like the console's avatar tiles */
+.avatarFrame {
+  flex-shrink: 0;
+  width: 96px;
+  height: 96px;
+  padding: 4px;
+  background: hsl(0 0% 13%);
+  border: 2px solid hsl(0 0% 40%);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-inset-light);
+  overflow: hidden;
+}
+
+.avatarImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+  border-radius: 2px;
+}
+
+.statList {
+  flex: 1;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--spacing-2);
+  min-width: 0;
+}
+
+.statRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.statLabel {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-light);
+  color: var(--color-text-secondary);
+}
+
+.statValue {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.gamerscoreIcon {
+  filter: brightness(1.2);
+}
+
+.headline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding: 0 var(--spacing-4) var(--spacing-3);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-brand-primary-light);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.status {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-brand-primary);
+  box-shadow: var(--shadow-glow-green);
+}
+
+.tagline {
+  margin: var(--spacing-1) 0 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-light);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-tertiary);
+  max-width: 48ch;
+}
+
+/* Save Contact — the primary recruiter action */
+.saveButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  align-self: flex-start;
+  margin: 0 var(--spacing-4) var(--spacing-4);
+  min-height: 44px;
+  padding: var(--spacing-2) var(--spacing-5);
+  background: var(--gradient-brand);
+  border: 1px solid var(--color-brand-primary-light);
+  border-radius: var(--radius-sm);
+  color: hsl(95 80% 8%);
+  font-family: inherit;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  cursor: pointer;
+  box-shadow: var(--shadow-glow-green), var(--shadow-inset-light);
+  transition: transform var(--duration-normal) var(--ease-smooth),
+    box-shadow var(--duration-normal) var(--ease-smooth),
+    filter var(--duration-normal) var(--ease-smooth);
+}
+
+.saveButton:hover,
+.saveButton:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-glow-green-hover), var(--shadow-inset-light);
+  filter: brightness(1.08);
+}
+
+.saveButton:active {
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .body {
+    padding: var(--spacing-4) var(--spacing-4) var(--spacing-3);
+  }
+
+  /* Save-contact goes full width and prominent on phones */
+  .saveButton {
+    align-self: stretch;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .saveButton,
+  .saveButton:hover {
+    transform: none;
+  }
+}

--- a/src/components/GamerCard/IdentityPanel.tsx
+++ b/src/components/GamerCard/IdentityPanel.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { memo } from 'react';
+import Image from 'next/image';
+import { Contact } from 'lucide-react';
+import { identity, stats } from '../../data/card';
+import styles from './IdentityPanel.module.css';
+
+interface IdentityPanelProps {
+  /** Owned by GamerCard so vCard download, sound and toast stay in one place. */
+  onSaveContact: () => void;
+  onHoverSound: () => void;
+}
+
+/**
+ * The right-pane identity block of the Profile screen:
+ * gamertag strip, gamerpic, stat rows and the Save Contact action.
+ */
+const IdentityPanel = memo<IdentityPanelProps>(({ onSaveContact, onHoverSound }) => {
+  return (
+    <div className={styles.identity}>
+      <div className={styles.gamertagStrip}>
+        <h1 className={styles.gamertag}>{identity.name}</h1>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.avatarFrame}>
+          <Image
+            src={identity.avatarSrc}
+            alt={`${identity.name} avatar`}
+            width={96}
+            height={96}
+            sizes="96px"
+            className={styles.avatarImage}
+            priority
+          />
+        </div>
+
+        <dl className={styles.statList}>
+          <div className={styles.statRow}>
+            <dt className={styles.statLabel}>Projects</dt>
+            <dd className={styles.statValue}>{stats.projects}</dd>
+          </div>
+          <div className={styles.statRow}>
+            <dt className={styles.statLabel}>Gamerscore</dt>
+            <dd className={styles.statValue}>
+              {stats.gamerscore.toLocaleString()}
+              <Image
+                src="/assets/icons/Gamerscore.gif"
+                alt=""
+                width={18}
+                height={18}
+                className={styles.gamerscoreIcon}
+              />
+            </dd>
+          </div>
+          <div className={styles.statRow}>
+            <dt className={styles.statLabel}>Achievements</dt>
+            <dd className={styles.statValue}>{stats.achievements}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className={styles.headline}>
+        <p className={styles.title}>{identity.title}</p>
+        <p className={styles.status}>
+          <span className={styles.statusDot} aria-hidden="true" />
+          {identity.statusLine}
+        </p>
+        <p className={styles.tagline}>{identity.tagline}</p>
+      </div>
+
+      <button
+        type="button"
+        className={styles.saveButton}
+        onClick={onSaveContact}
+        onMouseEnter={onHoverSound}
+      >
+        <Contact size={18} strokeWidth={1.75} aria-hidden="true" />
+        Save Contact
+      </button>
+    </div>
+  );
+});
+
+IdentityPanel.displayName = 'IdentityPanel';
+
+export default IdentityPanel;

--- a/src/components/GamerCard/MenuList.module.css
+++ b/src/components/GamerCard/MenuList.module.css
@@ -1,0 +1,50 @@
+.menu {
+  list-style: none;
+  margin: 0;
+  padding: var(--spacing-3) 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  min-height: 52px;
+  padding: 0 var(--spacing-4);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid hsl(0 0% 100% / 0.08);
+  color: var(--color-text-secondary);
+  font-family: inherit;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-light);
+  letter-spacing: var(--letter-spacing-wide);
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+  transition: color var(--duration-fast) var(--ease-smooth);
+}
+
+.menu li:last-child .row {
+  border-bottom: none;
+}
+
+/* The glossy green selection bar, straight off the reference screen */
+.rowSelected {
+  background: linear-gradient(
+    180deg,
+    hsl(var(--color-brand-hue) 65% 55%) 0%,
+    hsl(var(--color-brand-hue) 68% 42%) 48%,
+    hsl(var(--color-brand-hue) 72% 36%) 52%,
+    hsl(var(--color-brand-hue) 70% 42%) 100%
+  );
+  border-radius: 3px;
+  border-bottom-color: transparent;
+  color: hsl(95 85% 8%);
+  font-weight: var(--font-weight-regular);
+  text-shadow: 0 1px 0 hsl(0 0% 100% / 0.25);
+  box-shadow:
+    inset 0 1px 0 hsl(0 0% 100% / 0.35),
+    var(--shadow-glow-green);
+}

--- a/src/components/GamerCard/MenuList.tsx
+++ b/src/components/GamerCard/MenuList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { MenuItem } from './sections';
+import styles from './MenuList.module.css';
+
+interface MenuListProps {
+  items: MenuItem[];
+  /** Index of the row holding the green selection bar. */
+  cursorIndex: number;
+  onCursorChange: (index: number) => void;
+  onActivate: (item: MenuItem) => void;
+}
+
+/**
+ * Desktop-only left menu column replicating the blades-era Profile
+ * screen list ("View Games" / "Edit Profile" / ...): hairline-divided
+ * rows with a glossy green bar on the current selection.
+ */
+const MenuList = memo<MenuListProps>(({ items, cursorIndex, onCursorChange, onActivate }) => {
+  return (
+    <ul className={styles.menu} role="menu">
+      {items.map((item, index) => (
+        <li key={item.id} role="none">
+          <button
+            type="button"
+            role="menuitem"
+            className={`${styles.row} ${index === cursorIndex ? styles.rowSelected : ''}`}
+            onMouseEnter={() => onCursorChange(index)}
+            onFocus={() => onCursorChange(index)}
+            onClick={() => onActivate(item)}
+          >
+            {item.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+});
+
+MenuList.displayName = 'MenuList';
+
+export default MenuList;

--- a/src/components/GamerCard/TabBar.module.css
+++ b/src/components/GamerCard/TabBar.module.css
@@ -1,0 +1,66 @@
+.tabBar {
+  /* Mobile-only: shown in the 768px media query below */
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .tabBar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: var(--z-overlay);
+    display: flex;
+    background: hsl(0 0% 7% / 0.95);
+    backdrop-filter: var(--backdrop-blur);
+    border-top: 1px solid var(--color-border-secondary);
+    box-shadow: 0 -6px 16px hsl(0 0% 0% / 0.4);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .tab {
+    position: relative;
+    flex: 1;
+    min-height: 56px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: var(--spacing-2) 0;
+    background: transparent;
+    border: none;
+    color: var(--color-text-tertiary);
+    font-family: inherit;
+    cursor: pointer;
+    transition: color var(--duration-fast) var(--ease-smooth);
+  }
+
+  /* Green indicator bar along the top edge of the active tab */
+  .tab::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 20%;
+    right: 20%;
+    height: 3px;
+    border-radius: 0 0 3px 3px;
+    background: transparent;
+    transition: background var(--duration-fast) var(--ease-smooth),
+      box-shadow var(--duration-fast) var(--ease-smooth);
+  }
+
+  .tabActive {
+    color: var(--color-brand-primary-light);
+  }
+
+  .tabActive::before {
+    background: var(--color-brand-primary);
+    box-shadow: var(--shadow-glow-green);
+  }
+
+  .tabLabel {
+    font-size: var(--font-size-xs);
+    letter-spacing: var(--letter-spacing-wide);
+  }
+}

--- a/src/components/GamerCard/TabBar.tsx
+++ b/src/components/GamerCard/TabBar.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { SectionId } from './sections';
+import { TAB_ITEMS } from './sections';
+import styles from './TabBar.module.css';
+
+interface TabBarProps {
+  /** Section currently in view (driven by scroll-spy). */
+  activeId: SectionId;
+  onSelect: (id: SectionId) => void;
+}
+
+/**
+ * Mobile-only bottom tab bar: taps scroll to the matching section,
+ * the green indicator tracks whichever section is currently in view.
+ */
+const TabBar = memo<TabBarProps>(({ activeId, onSelect }) => {
+  return (
+    <nav className={styles.tabBar} aria-label="Card sections">
+      {TAB_ITEMS.map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          type="button"
+          className={`${styles.tab} ${id === activeId ? styles.tabActive : ''}`}
+          aria-current={id === activeId ? 'true' : undefined}
+          onClick={() => onSelect(id)}
+        >
+          <Icon size={20} strokeWidth={1.75} aria-hidden="true" />
+          <span className={styles.tabLabel}>{label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+});
+
+TabBar.displayName = 'TabBar';
+
+export default TabBar;

--- a/src/components/GamerCard/index.ts
+++ b/src/components/GamerCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GamerCard';
+export { default as GamerCard } from './GamerCard';

--- a/src/components/GamerCard/panes/ContactPane.tsx
+++ b/src/components/GamerCard/panes/ContactPane.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Clapperboard, Copy, Github, Globe, Linkedin, Mail } from 'lucide-react';
+import { useAudioManager } from '../../../hooks/useAudioManager';
+import { useToast, createSystemToast } from '../../ToastNotification';
+import { contacts, email } from '../../../data/card';
+import styles from './panes.module.css';
+
+const CONTACT_ICONS: Record<string, LucideIcon> = {
+  GitHub: Github,
+  LinkedIn: Linkedin,
+  Email: Mail,
+  Website: Globe,
+  Letterboxd: Clapperboard,
+};
+
+const ContactPane = memo(() => {
+  const { playSound } = useAudioManager();
+  const { showToast } = useToast();
+
+  const handleCopyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText(email);
+      playSound('ting');
+      showToast(createSystemToast('Email copied to clipboard', 'success'));
+    } catch {
+      showToast(createSystemToast('Could not copy — long-press the address instead', 'error'));
+    }
+  };
+
+  return (
+    <div className={styles.pane}>
+      <div className={styles.paneHeader}>
+        <Mail className={styles.paneHeaderIcon} size={20} strokeWidth={1.5} />
+        <h2 className={styles.paneTitle}>Contact</h2>
+      </div>
+
+      <ul className={styles.contactList}>
+        {contacts.map((contact) => {
+          const Icon = CONTACT_ICONS[contact.label] ?? Globe;
+          const isMail = contact.href.startsWith('mailto:');
+          return (
+            <li
+              key={contact.label}
+              className={contact.secondary ? styles.contactRowSecondary : styles.contactRow}
+            >
+              <a
+                className={styles.contactLink}
+                href={contact.href}
+                target={isMail ? undefined : '_blank'}
+                rel={isMail ? undefined : 'noopener noreferrer'}
+                onClick={() => playSound('click')}
+                onMouseEnter={() => playSound('hover')}
+              >
+                <Icon size={18} strokeWidth={1.5} aria-hidden="true" />
+                <span className={styles.contactLabel}>{contact.label}</span>
+                <span className={styles.contactDisplay}>{contact.display}</span>
+              </a>
+              {contact.label === 'Email' && (
+                <button
+                  type="button"
+                  className={styles.copyButton}
+                  onClick={handleCopyEmail}
+                  onMouseEnter={() => playSound('hover')}
+                  aria-label="Copy email address"
+                >
+                  <Copy size={16} strokeWidth={1.5} />
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+});
+
+ContactPane.displayName = 'ContactPane';
+
+export default ContactPane;

--- a/src/components/GamerCard/panes/ExperiencePane.tsx
+++ b/src/components/GamerCard/panes/ExperiencePane.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React, { memo } from 'react';
+import { Trophy } from 'lucide-react';
+import { roles } from '../../../data/card';
+import styles from './panes.module.css';
+
+/**
+ * Experience rendered as a list of "achievement unlocks" —
+ * one tile per role, with quantified impact bullets.
+ */
+const ExperiencePane = memo(() => {
+  return (
+    <div className={styles.pane}>
+      <div className={styles.paneHeader}>
+        <Trophy className={styles.paneHeaderIcon} size={20} strokeWidth={1.5} />
+        <h2 className={styles.paneTitle}>Experience</h2>
+      </div>
+
+      <ul className={styles.achievementList}>
+        {roles.map((role) => (
+          <li key={role.company} className={styles.achievement}>
+            <div className={styles.achievementIcon} aria-hidden="true">
+              <Trophy size={22} strokeWidth={1.5} />
+            </div>
+            <div className={styles.achievementBody}>
+              <h3 className={styles.achievementTitle}>
+                {role.title} — {role.company}
+              </h3>
+              <p className={styles.achievementMeta}>
+                {role.period} · {role.location}
+              </p>
+              <ul className={styles.bullets}>
+                {role.bullets.map((bullet) => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});
+
+ExperiencePane.displayName = 'ExperiencePane';
+
+export default ExperiencePane;

--- a/src/components/GamerCard/panes/SkillsPane.tsx
+++ b/src/components/GamerCard/panes/SkillsPane.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { memo } from 'react';
+import { Award, GraduationCap, Wrench } from 'lucide-react';
+import { credentials, education, skillGroups } from '../../../data/card';
+import styles from './panes.module.css';
+
+const SkillsPane = memo(() => {
+  return (
+    <div className={styles.pane}>
+      <div className={styles.paneHeader}>
+        <Wrench className={styles.paneHeaderIcon} size={20} strokeWidth={1.5} />
+        <h2 className={styles.paneTitle}>Skills &amp; Certs</h2>
+      </div>
+
+      <div className={styles.skillGroups}>
+        {skillGroups.map((group) => (
+          <div key={group.label} className={styles.skillGroup}>
+            <h3 className={styles.skillGroupLabel}>{group.label}</h3>
+            <ul className={styles.chips}>
+              {group.items.map((item) => (
+                <li key={item} className={styles.chip}>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <p className={styles.educationLine}>
+        <GraduationCap size={16} strokeWidth={1.5} aria-hidden="true" />
+        {education}
+      </p>
+
+      <ul className={styles.credGrid}>
+        {credentials.map((credential) => (
+          <li key={credential.title} className={styles.credTile}>
+            <div className={styles.credIcon} aria-hidden="true">
+              <Award size={22} strokeWidth={1.5} />
+            </div>
+            <span className={styles.credLabel}>
+              {credential.title}
+              <span className={styles.credIssuer}>{credential.issuer}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});
+
+SkillsPane.displayName = 'SkillsPane';
+
+export default SkillsPane;

--- a/src/components/GamerCard/panes/WorkPane.tsx
+++ b/src/components/GamerCard/panes/WorkPane.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { memo } from 'react';
+import { FolderGit2 } from 'lucide-react';
+import { projects } from '../../../data/card';
+import styles from './panes.module.css';
+
+const WorkPane = memo(() => {
+  return (
+    <div className={styles.pane}>
+      <div className={styles.paneHeader}>
+        <FolderGit2 className={styles.paneHeaderIcon} size={20} strokeWidth={1.5} />
+        <h2 className={styles.paneTitle}>Selected Work</h2>
+      </div>
+
+      <ul className={styles.workList}>
+        {projects.map((project) => (
+          <li key={project.name} className={styles.workItem}>
+            <div className={styles.workHeading}>
+              <h3 className={styles.workName}>{project.name}</h3>
+              <span className={styles.workStack}>{project.stack}</span>
+            </div>
+            <p className={styles.workDescription}>{project.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+});
+
+WorkPane.displayName = 'WorkPane';
+
+export default WorkPane;

--- a/src/components/GamerCard/panes/panes.module.css
+++ b/src/components/GamerCard/panes/panes.module.css
@@ -1,0 +1,378 @@
+/* Shared styles for the GamerCard content panes */
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+}
+
+.paneHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding-bottom: var(--spacing-2);
+  border-bottom: 1px solid var(--color-border-primary);
+}
+
+.paneHeaderIcon {
+  color: #a8a8a8;
+  filter:
+    drop-shadow(0 0 1px rgb(255 255 255 / 30%))
+    drop-shadow(0 1px 2px rgb(0 0 0 / 50%));
+}
+
+.paneTitle {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+/* ============ Experience — achievement rows ============ */
+
+.achievementList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.achievement {
+  display: flex;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3);
+  background: hsl(0 0% 100% / 0.04);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-base);
+  box-shadow: var(--shadow-inset-light);
+  transition: background var(--duration-normal) var(--ease-smooth),
+    transform var(--duration-normal) var(--ease-smooth);
+}
+
+.achievement:hover {
+  background: hsl(0 0% 100% / 0.07);
+  transform: translateY(-2px);
+}
+
+.achievementIcon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, hsl(200 4% 33%), hsl(200 6% 20%));
+  border: 1px solid hsl(0 0% 100% / 0.15);
+  border-radius: var(--radius-sm);
+  color: var(--color-brand-primary-light);
+  box-shadow: var(--shadow-inset-light);
+}
+
+.achievementBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  min-width: 0;
+}
+
+.achievementTitle {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.achievementMeta {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+.bullets {
+  margin: var(--spacing-1) 0 0;
+  padding-left: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-light);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
+}
+
+.bullets li::marker {
+  color: var(--color-brand-primary);
+}
+
+/* ============ Selected work ============ */
+
+.workList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.workItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding-bottom: var(--spacing-3);
+  border-bottom: 1px solid hsl(0 0% 100% / 0.06);
+}
+
+.workItem:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.workHeading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
+}
+
+.workName {
+  margin: 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.workStack {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-brand-primary-light);
+}
+
+.workDescription {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-light);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+/* ============ Skills & certs ============ */
+
+.skillGroups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.skillGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.skillGroupLabel {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--color-text-tertiary);
+}
+
+.chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.chip {
+  padding: var(--spacing-1) var(--spacing-3);
+  background: hsl(0 0% 100% / 0.06);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-light);
+  color: var(--color-text-secondary);
+}
+
+.educationLine {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.educationLine svg {
+  flex-shrink: 0;
+  color: var(--color-brand-primary-light);
+}
+
+.credGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--spacing-2);
+}
+
+.credTile {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
+  background: hsl(0 0% 100% / 0.04);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+}
+
+.credIcon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, hsl(200 4% 33%), hsl(200 6% 20%));
+  border: 1px solid hsl(0 0% 100% / 0.15);
+  border-radius: var(--radius-sm);
+  color: var(--color-brand-primary-light);
+}
+
+.credLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  color: var(--color-text-primary);
+  line-height: var(--line-height-tight);
+}
+
+.credIssuer {
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-weight-light);
+}
+
+/* ============ Contact ============ */
+
+.contactList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.contactRow,
+.contactRowSecondary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  border-bottom: 1px solid hsl(0 0% 100% / 0.06);
+}
+
+.contactRow:last-child,
+.contactRowSecondary:last-child {
+  border-bottom: none;
+}
+
+.contactRowSecondary {
+  opacity: 0.65;
+}
+
+.contactLink {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  min-height: 44px;
+  padding: var(--spacing-2) 0;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: color var(--duration-fast) var(--ease-smooth);
+  min-width: 0;
+}
+
+.contactLink:hover,
+.contactLink:focus-visible {
+  color: var(--color-brand-primary-light);
+}
+
+.contactLink:focus-visible {
+  outline-color: var(--color-brand-primary);
+}
+
+.contactLink svg {
+  flex-shrink: 0;
+}
+
+.contactLabel {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-regular);
+  min-width: 5.5rem;
+}
+
+.contactDisplay {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copyButton {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-smooth),
+    border-color var(--duration-fast) var(--ease-smooth),
+    background var(--duration-fast) var(--ease-smooth);
+}
+
+.copyButton:hover,
+.copyButton:focus-visible {
+  color: var(--color-brand-primary-light);
+  border-color: var(--color-brand-primary);
+  background: hsl(var(--color-brand-hue) var(--color-brand-saturation) 45% / 0.1);
+}
+
+/* Mobile — tighter padding, everything remains tappable */
+@media (max-width: 768px) {
+  .pane {
+    padding: var(--spacing-4) var(--spacing-4) var(--spacing-5);
+  }
+
+  .credGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .contactDisplay {
+    display: none;
+  }
+}

--- a/src/components/GamerCard/sections.ts
+++ b/src/components/GamerCard/sections.ts
@@ -1,0 +1,46 @@
+import type { LucideIcon } from 'lucide-react';
+import { FolderGit2, Mail, Trophy, User, Wrench } from 'lucide-react';
+
+export type SectionId = 'profile' | 'experience' | 'work' | 'skills' | 'contact';
+
+/** DOM ids used as scroll targets on mobile. */
+export const sectionDomId = (id: SectionId) => `gc-${id}`;
+
+export const SECTION_DOM_IDS: readonly string[] = [
+  'gc-profile',
+  'gc-experience',
+  'gc-work',
+  'gc-skills',
+  'gc-contact',
+];
+
+export interface MenuItem {
+  kind: 'section' | 'action';
+  id: SectionId | 'save-contact' | 'dashboard';
+  label: string;
+}
+
+/** Desktop left-column menu, mirroring the blades-era Profile screen. */
+export const MENU_ITEMS: MenuItem[] = [
+  { kind: 'section', id: 'experience', label: 'View Experience' },
+  { kind: 'section', id: 'work', label: 'Selected Work' },
+  { kind: 'section', id: 'skills', label: 'Skills & Certs' },
+  { kind: 'section', id: 'contact', label: 'Contact' },
+  { kind: 'action', id: 'save-contact', label: 'Save Contact' },
+  { kind: 'action', id: 'dashboard', label: 'Enter Dashboard' },
+];
+
+export interface TabItem {
+  id: SectionId;
+  label: string;
+  Icon: LucideIcon;
+}
+
+/** Mobile bottom tab bar. */
+export const TAB_ITEMS: TabItem[] = [
+  { id: 'profile', label: 'Profile', Icon: User },
+  { id: 'experience', label: 'Experience', Icon: Trophy },
+  { id: 'work', label: 'Work', Icon: FolderGit2 },
+  { id: 'skills', label: 'Skills', Icon: Wrench },
+  { id: 'contact', label: 'Contact', Icon: Mail },
+];

--- a/src/data/card.ts
+++ b/src/data/card.ts
@@ -1,0 +1,171 @@
+/**
+ * Content source of truth for the /card Gamercard business card.
+ * Every string rendered on the card (and embedded in the vCard) lives here.
+ */
+
+export interface CardIdentity {
+  name: string;
+  title: string;
+  org: string;
+  statusLine: string;
+  tagline: string;
+  location: string;
+  avatarSrc: string;
+}
+
+export interface CardStats {
+  projects: number;
+  /** Playful nod to the Xbox metric — tune freely. */
+  gamerscore: number;
+  achievements: number;
+}
+
+export interface CardRole {
+  company: string;
+  title: string;
+  period: string;
+  location: string;
+  bullets: string[];
+}
+
+export interface CardProject {
+  name: string;
+  stack: string;
+  description: string;
+}
+
+export interface CardSkillGroup {
+  label: string;
+  items: string[];
+}
+
+export interface CardCredential {
+  title: string;
+  issuer: string;
+}
+
+export interface CardContact {
+  label: string;
+  href: string;
+  display: string;
+  /** Secondary links render smaller, off the main recruiter path. */
+  secondary?: boolean;
+}
+
+export const identity: CardIdentity = {
+  name: 'SOROS FEBRIANO',
+  title: 'Pragmatic Software Engineer',
+  org: 'MisiPNS',
+  statusLine: 'Online — open to interesting problems',
+  tagline:
+    'Purposeful, meticulously engineered software for real people — practical over trendy.',
+  location: 'Jakarta, Indonesia',
+  avatarSrc: '/assets/images/myBody.webp',
+};
+
+export const email = 'mail@sorosfebria.co';
+export const websiteUrl = 'https://www.sorosfebria.co';
+
+export const roles: CardRole[] = [
+  {
+    company: 'MisiPNS',
+    title: 'Founding Product Engineer',
+    period: 'Jan 2026 — Present',
+    location: 'Remote',
+    bullets: [
+      'Built a token-based React Native UI library — 22 core / 100+ components, Material Design 3, 60fps with Reanimated',
+      'A/B-tested onboarding & paywall flows, lifting conversion from 1% to 5%',
+      'Optimistic UI and caching architecture with Zustand and React Query',
+    ],
+  },
+  {
+    company: 'Nanovest',
+    title: 'QA Engineer',
+    period: 'Aug 2025 — Jan 2026',
+    location: 'Jakarta',
+    bullets: [
+      'Autonomous test pipeline (Python, Robot Framework, Playwright) cutting manual regression time ~80%',
+      'AI agents (Claude Code Workflows) tripling test-script authoring speed',
+      '99.9% suite stability; 70+ defects caught on RN New Architecture',
+    ],
+  },
+  {
+    company: 'ALVA',
+    title: 'Full Stack Engineer',
+    period: 'May 2025 — Jul 2025',
+    location: 'Jakarta',
+    bullets: [
+      'Shipped the "FRnD Chat" Next.js frontend with a brand-constrained markdown pipeline',
+      'Automated video workflows producing 1,000+ videos/month',
+      'AI creative tools reducing editing time ~25%',
+    ],
+  },
+];
+
+export const projects: CardProject[] = [
+  {
+    name: 'Tangan Kanan',
+    stack: 'Next.js · Convex · LangGraph',
+    description: 'Agentic assistant platform built end-to-end.',
+  },
+  {
+    name: 'SiNgawas',
+    stack: 'Top 3 of 24 — award',
+    description: 'Supervision platform; placed Top 3 of 24 teams.',
+  },
+  {
+    name: 'EpicArcade',
+    stack: 'Spring Boot · GCP · TDD',
+    description: 'Microservices arcade store, test-driven on Google Cloud.',
+  },
+];
+
+export const skillGroups: CardSkillGroup[] = [
+  { label: 'Languages', items: ['TypeScript', 'JavaScript', 'Python', 'Java', 'Go'] },
+  {
+    label: 'Frontend',
+    items: ['React', 'Next.js', 'React Native', 'Vue', 'TanStack', 'Tailwind', 'Zustand'],
+  },
+  {
+    label: 'Backend & Data',
+    items: ['Django', 'Spring Boot', 'PostgreSQL', 'Supabase', 'Convex'],
+  },
+  {
+    label: 'Infra & Quality',
+    items: ['Docker', 'Kubernetes', 'GCP', 'Nginx', 'CI/CD', 'Playwright', 'Grafana'],
+  },
+  { label: 'AI & Design', items: ['LangGraph', 'PyTorch', 'Figma', 'Storybook'] },
+];
+
+export const education = 'B.Sc. Computer Science — Universitas Indonesia (2022–2026, expected)';
+
+export const credentials: CardCredential[] = [
+  { title: 'Associate AI Engineer', issuer: 'DataCamp' },
+  { title: 'Kubernetes Skill Badge', issuer: 'Google Cloud' },
+  { title: 'Security Skill Badge', issuer: 'Google Cloud' },
+  { title: 'Gemini Pro Skill Badge', issuer: 'Google Cloud' },
+  { title: 'Top 3 of 24 — SiNgawas', issuer: 'Competition award' },
+];
+
+export const contacts: CardContact[] = [
+  { label: 'GitHub', href: 'https://github.com/sorfeb', display: 'github.com/sorfeb' },
+  {
+    label: 'LinkedIn',
+    href: 'https://www.linkedin.com/in/soros-febriano/',
+    display: 'linkedin.com/in/soros-febriano',
+  },
+  { label: 'Email', href: `mailto:${email}`, display: email },
+  { label: 'Website', href: websiteUrl, display: 'sorosfebria.co' },
+  {
+    label: 'Letterboxd',
+    href: 'https://letterboxd.com/21watchingeyes/',
+    display: 'beyond code',
+    secondary: true,
+  },
+];
+
+export const stats: CardStats = {
+  projects: projects.length + roles.length,
+  gamerscore: 10250,
+  achievements: credentials.length,
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useInterval } from './useInterval';
 export { useTimeout } from './useTimeout';
 export { useEventListener } from './useEventListener';
 export { useAutoScroll } from './useAutoScroll';
+export { useScrollSpy } from './useScrollSpy';

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Tracks which page section currently occupies the middle of the viewport.
+ *
+ * Observes the elements matching `sectionIds` with an IntersectionObserver
+ * whose active band is a thin horizontal strip near the viewport center, so
+ * exactly one section is "current" while scrolling. Sections hidden with
+ * `display: none` never intersect and are simply ignored.
+ *
+ * Pass a module-level constant (or otherwise stable) array for `sectionIds`.
+ */
+export function useScrollSpy(sectionIds: readonly string[]): string | null {
+  const [activeId, setActiveId] = useState<string | null>(sectionIds[0] ?? null);
+
+  useEffect(() => {
+    const sections = sectionIds
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      // Active band: a strip from 40% to 55% of viewport height
+      { rootMargin: '-40% 0px -55% 0px', threshold: 0 }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, [sectionIds]);
+
+  return activeId;
+}

--- a/src/utils/vcard.ts
+++ b/src/utils/vcard.ts
@@ -1,0 +1,53 @@
+import { contacts, email, identity, websiteUrl } from '../data/card';
+
+/**
+ * Builds a vCard 3.0 string from the card data.
+ * Deliberately omits TEL — email is the only contact channel.
+ */
+export function buildVCard(): string {
+  const [firstName, ...rest] = identity.name.split(' ');
+  const lastName = rest.join(' ');
+  const linkedIn = contacts.find((c) => c.label === 'LinkedIn')?.href;
+  const gitHub = contacts.find((c) => c.label === 'GitHub')?.href;
+
+  const lines = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `N:${toTitleCase(lastName)};${toTitleCase(firstName)};;;`,
+    `FN:${toTitleCase(identity.name)}`,
+    `TITLE:${identity.title}`,
+    `ORG:${identity.org}`,
+    `EMAIL;TYPE=INTERNET:${email}`,
+    `URL:${websiteUrl}`,
+    ...(linkedIn ? [`URL:${linkedIn}`] : []),
+    ...(gitHub ? [`URL:${gitHub}`] : []),
+    `ADR;TYPE=WORK:;;;${identity.location.replace(', ', ';;;')}`,
+    `NOTE:${identity.tagline}`,
+    'END:VCARD',
+  ];
+
+  // vCard spec requires CRLF line endings
+  return lines.join('\r\n');
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/(^|\s)\S/g, (char) => char.toUpperCase());
+}
+
+/**
+ * Triggers a client-side download of the vCard so the OS offers
+ * "Add to Contacts" — no server round-trip, no dependency.
+ */
+export function downloadVCard(filename = 'soros-febriano.vcf'): void {
+  const blob = new Blob([buildVCard()], { type: 'text/vcard;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Adds `/card-pilot`, a standalone pilot for the `/card` redesign: the Xbox 360 blades-era **Profile screen** rebuilt as a business card, leaving live `/card` untouched during QA.
- Desktop replicates the reference two-column screen: left menu with the glossy green selection bar drives which content pane shows on the right; chrome header (title / gamerpic / clock) and Ⓐ Select / Ⓑ Back footer; full keyboard control (↑/↓, Enter, Esc).
- Mobile (≤768px) is one vertically scrollable column with a fixed bottom tab bar — taps scroll to the section, and a scroll-spy green indicator tracks the section currently in view.

## Changes
- `src/data/card.ts` — typed content source of truth (identity, roles, projects, skills, credentials, contacts, stats)
- `src/utils/vcard.ts` — client-side vCard 3.0 builder + download (email-only, no `TEL`); wired to **Save Contact** with achievement sound + toast
- `src/hooks/useScrollSpy.ts` — IntersectionObserver hook powering the mobile tab-bar indicator
- `src/components/GamerCard/` — `GamerCard` root, `MenuList`, `TabBar`, `IdentityPanel`, four content panes (experience as achievement unlocks, selected work, skills & certs, contact with copy-email), Storybook story
- `src/app/card-pilot/` — thin route + `noindex` metadata; excluded from the sitemap

## Test Plan
- `npm run compile` ✅ and `npm run lint:useeffect` ✅ (no direct `useEffect` in components)
- QA on `dev` at `/card-pilot`:
  - Desktop: menu hover/click sounds, green bar movement, pane swap animation, keyboard nav, Ⓐ/Ⓑ footer, Save Contact downloads a valid `.vcf`
  - Mobile (≤430px): single-column scroll, bottom tabs scroll to sections, indicator follows scroll, Save Contact full-width ≥44px, copy-email toast
  - `prefers-reduced-motion` disables pane/scroll animations

## Notes (pre-existing issues, reproduced on clean `dev`)
- `npm run lint` crashes repo-wide: the `"ajv": "^8.17.1"` entry in package.json `overrides` breaks `@eslint/eslintrc` (needs ajv v6)
- `next build` fails prerendering `/` with `window is not defined` — unrelated to this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)