### PR TITLE
fix: revive ESLint and fix home-page prerender — production builds pass again

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,11 @@
   "extends": [
     "next/core-web-vitals",
     "plugin:storybook/recommended"
-  ]
+  ],
+  "rules": {
+    // Storybook 7 requires importing Meta/StoryObj from the renderer
+    // package (@storybook/react) — framework packages don't re-export
+    // them until SB9. Re-enable this rule after upgrading Storybook.
+    "storybook/no-renderer-packages": "off"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,6 +3064,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -3076,6 +3093,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.29.0",
@@ -11217,6 +11241,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -11549,6 +11597,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12084,6 +12139,23 @@
         }
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -12108,6 +12180,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "3.3.0",
@@ -16560,6 +16639,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -20163,6 +20252,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-resize-observer": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "typescript": "^5"
   },
   "overrides": {
-    "ajv": "^8.17.1",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6"
   }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -9,7 +9,7 @@ const AboutPage = () => {
       <PageLayout.Header />
       <PageLayout.Body>
         <p>
-        <i>The "NXE" update, which stands for "New Xbox Experience," 
+        <i>The &ldquo;NXE&rdquo; update, which stands for &ldquo;New Xbox Experience,&rdquo;
           was a major system update for the Xbox 360 that significantly 
           redesigned the dashboard, adding features like avatar creation, 
           the ability to install games directly to the hard drive for faster loading times, 

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -35,7 +35,7 @@ const MusicPage = () => {
         <div className={styles.playerWrapper}>
           <div className={styles.instructions}>
             <h2>Windows Media Player</h2>
-            <p>Click "Show Player" to open the global music player.</p>
+            <p>Click &ldquo;Show Player&rdquo; to open the global music player.</p>
             <p>The player is draggable and persists across pages.</p>
             {isLoading && <p className={styles.loading}>Loading playlist...</p>}
             {!isLoading && catalog && catalog.length === 0 && (

--- a/src/app/my-playlists/page.tsx
+++ b/src/app/my-playlists/page.tsx
@@ -113,7 +113,7 @@ const PlaylistsPage = () => {
           )}
           {emptyPlaylistName && (
             <div className={styles.errorMessage}>
-              <p>"{emptyPlaylistName}" has no playable tracks.</p>
+              <p>&ldquo;{emptyPlaylistName}&rdquo; has no playable tracks.</p>
             </div>
           )}
         </div>

--- a/src/components/Chat/ChatWindow/ChatWindow.tsx
+++ b/src/components/Chat/ChatWindow/ChatWindow.tsx
@@ -55,7 +55,9 @@ const ChatWindow = memo<ChatWindowProps>(({ isOpen, onClose, onMinimize }) => {
   });
 
   // Keep mobile flag in sync with viewport width
-  useEventListener(window, 'resize', () => setMobile(isMobile()));
+  useEventListener(typeof window === 'undefined' ? null : window, 'resize', () =>
+    setMobile(isMobile())
+  );
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
     if (isMaximized || mobile) return;

--- a/src/components/ScrollingMenu/ScrollingMenu.tsx
+++ b/src/components/ScrollingMenu/ScrollingMenu.tsx
@@ -46,7 +46,7 @@ const ScrollingMenu: React.FC<ScrollingMenuProps> = ({ items, onSelectionChange,
 
   // Scroll wheel navigation
   useEventListener(
-    disabled ? null : window,
+    disabled || typeof window === 'undefined' ? null : window,
     'wheel',
     (event: WheelEvent) => {
       const direction = Math.sign(event.deltaY);

--- a/src/components/XboxCard/card/XboxCard.tsx
+++ b/src/components/XboxCard/card/XboxCard.tsx
@@ -84,4 +84,6 @@ const XboxCard: React.FC<XboxCardProps> = memo(({ title, iconUrl, route, images 
   );
 });
 
+XboxCard.displayName = 'XboxCard';
+
 export default XboxCard;

--- a/src/stories/Page.tsx
+++ b/src/stories/Page.tsx
@@ -36,7 +36,7 @@ export const Page: React.FC = () => {
         <ul>
           <li>
             Use a higher-level connected component. Storybook helps you compose such data from the
-            "args" of child component stories
+            &ldquo;args&rdquo; of child component stories
           </li>
           <li>
             Assemble data in the page component from your services. You can mock these services out


### PR DESCRIPTION
## Summary
Fixes the two pre-existing build blockers that prevented shipping `dev` → `main`. `next build` now completes end-to-end: **all 23 pages prerender, zero lint errors.**

- **ESLint was crashing repo-wide** (`NOT SUPPORTED: option missingRefs`): the blanket `"ajv": "^8.17.1"` entry in package.json `overrides` (added incidentally in an old refactor commit) forced ESLint's config loader — written against ajv v6 — onto v8. Removing the override lets every package resolve its own declared ajv major.
- **Home page failed prerender** (`window is not defined`): `ScrollingMenu` passed a bare `window` as a `useEventListener` target, which evaluates during SSR. `ChatWindow` had the same latent bug. Both now pass `null` during SSR, matching the guard pattern used elsewhere.
- **Lint errors surfaced by the revived ESLint** (invisible while it crashed): escaped quotes flagged by `react/no-unescaped-entities` (4 files), added `XboxCard.displayName`, and disabled `storybook/no-renderer-packages` with a comment — Storybook 7 framework packages don't export `Meta`/`StoryObj` (that's SB9), so renderer imports are correct for this repo until the upgrade.

Remaining lint **warnings** (12× `react-hooks/exhaustive-deps`, 2× `no-img-element`) don't fail builds — left for a separate cleanup pass.

Note: the SSR guards were meant to be their own commit but got folded into the lint-fixes commit by a shell quoting mishap; the diff is the same.

## Test Plan
- `npm run lint` → exits 0 (first time in months, presumably)
- `npm run compile` → clean
- `next build` → compiled, lint stage passed, **23/23 static pages generated** including `/` and `/card-pilot`
- Home page behavior unchanged: wheel navigation on the dashboard still works (listener now just skips attaching during SSR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)