### PR TITLE
feat: concept graph — wikilink passages, chips, and backlink popovers on /card

### DIFF
--- a/src/app/card/Card.module.css
+++ b/src/app/card/Card.module.css
@@ -68,8 +68,11 @@
 .identity { animation-delay: 80ms; }
 .bio      { animation-delay: 160ms; }
 .section:nth-of-type(1) { animation-delay: 240ms; }
-.section:nth-of-type(2) { animation-delay: 320ms; }
-.footer   { animation-delay: 400ms; }
+.section:nth-of-type(2) { animation-delay: 300ms; }
+.section:nth-of-type(3) { animation-delay: 360ms; }
+.section:nth-of-type(4) { animation-delay: 420ms; }
+.section:nth-of-type(5) { animation-delay: 480ms; }
+.footer   { animation-delay: 540ms; }
 
 .chip {
   display: inline-flex;

--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -3,6 +3,13 @@
 import React, { useMemo } from 'react';
 import Link from 'next/link';
 import projectsData from '../../data/projects.json';
+import {
+  CARD_COLOPHON,
+  CARD_CONCEPT_SOURCES,
+  CARD_INSPIRATIONS,
+  CARD_INTERESTS,
+} from '../../data/concepts';
+import { ChipGroup, ConceptGraphProvider, Passage } from '../../components/Concept';
 import { useAudioManager } from '../../hooks/useAudioManager';
 import { useMountEffect } from '../../hooks';
 import { useNavigationSound } from '../../hooks/useNavigationSound';
@@ -84,6 +91,7 @@ const CardPage: React.FC = () => {
 
   return (
     <main className={styles.page}>
+      <ConceptGraphProvider sources={CARD_CONCEPT_SOURCES}>
       <div className={styles.column}>
         <div className={styles.chip}>
           <span className={styles.chipBar} aria-hidden="true" />
@@ -101,6 +109,11 @@ const CardPage: React.FC = () => {
         </p>
 
         <section className={styles.section}>
+          <h2 className={styles.sectionLabel}>Current interests</h2>
+          <Passage section={CARD_INTERESTS} />
+        </section>
+
+        <section className={styles.section}>
           <h2 className={styles.sectionLabel}>Selected work</h2>
           <ul className={styles.workList}>
             {featured.map((entry) => (
@@ -113,6 +126,16 @@ const CardPage: React.FC = () => {
               </li>
             ))}
           </ul>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionLabel}>Colophon</h2>
+          <ChipGroup chips={CARD_COLOPHON.chips} />
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionLabel}>Inspirations</h2>
+          <ChipGroup chips={CARD_INSPIRATIONS.chips} />
         </section>
 
         <section className={styles.section}>
@@ -147,6 +170,7 @@ const CardPage: React.FC = () => {
           </Link>
         </footer>
       </div>
+      </ConceptGraphProvider>
     </main>
   );
 };

--- a/src/components/Concept/ChipGroup.stories.tsx
+++ b/src/components/Concept/ChipGroup.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ChipGroup from './ChipGroup';
+import ConceptGraphProvider from './ConceptGraphProvider';
+import { VolumeProvider } from '../../context/VolumeContext';
+import {
+  CARD_COLOPHON,
+  CARD_CONCEPT_SOURCES,
+  CARD_INSPIRATIONS,
+} from '../../data/concepts';
+
+/**
+ * ChipGroup renders concept chips — standalone mentions with contextual
+ * display text (version ranges, harness pairings) that stays out of the
+ * concept registry.
+ */
+const meta: Meta<typeof ChipGroup> = {
+  title: 'Concept Graph/ChipGroup',
+  component: ChipGroup,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Chips whose label and note both support [[wikilink]] mentions; free text (e.g. "GLM 4.6 → 5.1") is display-only context.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <VolumeProvider>
+        <ConceptGraphProvider sources={CARD_CONCEPT_SOURCES}>
+          <div
+            style={{
+              width: '460px',
+              padding: '2rem',
+              background: 'hsl(0 0% 4%)',
+              color: 'hsl(0 0% 90%)',
+            }}
+          >
+            <Story />
+          </div>
+        </ConceptGraphProvider>
+      </VolumeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Colophon: Story = {
+  args: {
+    chips: CARD_COLOPHON.chips,
+  },
+};
+
+export const Inspirations: Story = {
+  args: {
+    chips: CARD_INSPIRATIONS.chips,
+  },
+};

--- a/src/components/Concept/ChipGroup.tsx
+++ b/src/components/Concept/ChipGroup.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { ConceptChipSpec } from '@/data/concepts';
+import ConceptChip from './ConceptChip';
+import styles from './ConceptChip.module.css';
+
+interface ChipGroupProps {
+  chips: ConceptChipSpec[];
+}
+
+const ChipGroup = memo<ChipGroupProps>(({ chips }) => (
+  <ul className={styles.chipList}>
+    {chips.map((chip) => (
+      <ConceptChip key={chip.label} chip={chip} />
+    ))}
+  </ul>
+));
+
+ChipGroup.displayName = 'ChipGroup';
+
+export default ChipGroup;

--- a/src/components/Concept/ConceptChip.module.css
+++ b/src/components/Concept/ConceptChip.module.css
@@ -1,0 +1,54 @@
+.chipList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--spacing-2);
+
+  padding: var(--spacing-2) var(--spacing-3);
+
+  background: hsl(0 0% 100% / 0.03);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-sm);
+
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-light);
+  transition: border-color var(--duration-fast) var(--ease-smooth);
+}
+
+.chip:hover {
+  border-color: var(--color-border-secondary);
+}
+
+.label {
+  color: var(--color-text-primary);
+  letter-spacing: var(--letter-spacing-wide);
+  white-space: nowrap;
+}
+
+.note {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  letter-spacing: var(--letter-spacing-normal);
+}
+
+@media (max-width: 768px) {
+  .chip {
+    flex-direction: column;
+    gap: var(--spacing-1);
+    min-height: 44px;
+    justify-content: center;
+  }
+
+  .label {
+    white-space: normal;
+  }
+}

--- a/src/components/Concept/ConceptChip.tsx
+++ b/src/components/Concept/ConceptChip.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { ConceptChipSpec } from '@/data/concepts';
+import WikilinkText from './WikilinkText';
+import styles from './ConceptChip.module.css';
+
+interface ConceptChipProps {
+  chip: ConceptChipSpec;
+}
+
+const ConceptChip = memo<ConceptChipProps>(({ chip }) => (
+  <li className={styles.chip}>
+    <span className={styles.label}>
+      <WikilinkText text={chip.label} />
+    </span>
+    {chip.note && (
+      <span className={styles.note}>
+        <WikilinkText text={chip.note} />
+      </span>
+    )}
+  </li>
+));
+
+ConceptChip.displayName = 'ConceptChip';
+
+export default ConceptChip;

--- a/src/components/Concept/ConceptGraphProvider.tsx
+++ b/src/components/Concept/ConceptGraphProvider.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { useEventListener } from '@/hooks';
+import { useAudioManager } from '@/hooks/useAudioManager';
+import type { ConceptSource } from '@/data/concepts';
+import { buildBacklinkIndex, ConceptBacklink } from '@/utils/conceptGraph';
+import ConceptPopover from './ConceptPopover';
+
+const POPOVER_WIDTH = 320;
+const POPOVER_EST_HEIGHT = 280;
+const POPOVER_GAP = 8;
+const VIEWPORT_MARGIN = 12;
+
+interface PopoverState {
+  conceptId: string;
+  top: number;
+  left: number;
+  placement: 'below' | 'above';
+}
+
+interface ConceptGraphContextValue {
+  activeConceptId: string | null;
+  openConcept: (conceptId: string, anchor: HTMLElement) => void;
+  closeConcept: () => void;
+  /** Switch the open popover to another concept in place. */
+  showConcept: (conceptId: string) => void;
+  getBacklinks: (conceptId: string) => ConceptBacklink[];
+}
+
+const ConceptGraphContext = createContext<ConceptGraphContextValue | null>(null);
+
+export function useConceptGraph(): ConceptGraphContextValue {
+  const context = useContext(ConceptGraphContext);
+  if (!context) {
+    throw new Error('useConceptGraph must be used within a ConceptGraphProvider');
+  }
+  return context;
+}
+
+interface ConceptGraphProviderProps {
+  /** Content blocks scanned for mentions to derive the backlink index. */
+  sources: ConceptSource[];
+  children: React.ReactNode;
+}
+
+const ConceptGraphProvider: React.FC<ConceptGraphProviderProps> = ({
+  sources,
+  children,
+}) => {
+  const { playSound } = useAudioManager();
+  const [popover, setPopover] = useState<PopoverState | null>(null);
+
+  const backlinkIndex = useMemo(() => buildBacklinkIndex(sources), [sources]);
+
+  const getBacklinks = useCallback(
+    (conceptId: string) => backlinkIndex.get(conceptId) ?? [],
+    [backlinkIndex],
+  );
+
+  const openConcept = useCallback(
+    (conceptId: string, anchor: HTMLElement) => {
+      const rect = anchor.getBoundingClientRect();
+      const placement: PopoverState['placement'] =
+        rect.bottom + POPOVER_GAP + POPOVER_EST_HEIGHT > window.innerHeight &&
+        rect.top > POPOVER_EST_HEIGHT
+          ? 'above'
+          : 'below';
+      const left = Math.min(
+        Math.max(rect.left, VIEWPORT_MARGIN),
+        Math.max(window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
+      );
+      const top =
+        placement === 'below' ? rect.bottom + POPOVER_GAP : rect.top - POPOVER_GAP;
+      playSound('unfold');
+      setPopover({ conceptId, top, left, placement });
+    },
+    [playSound],
+  );
+
+  const closeConcept = useCallback(() => {
+    if (popover) {
+      playSound('back');
+      setPopover(null);
+    }
+  }, [popover, playSound]);
+
+  const showConcept = useCallback(
+    (conceptId: string) => {
+      playSound('click');
+      setPopover((current) => (current ? { ...current, conceptId } : current));
+    },
+    [playSound],
+  );
+
+  const doc = typeof document !== 'undefined' ? document : null;
+  const win = typeof window !== 'undefined' ? window : null;
+
+  useEventListener(popover ? doc : null, 'pointerdown', (event) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('[data-concept-ui]')) return;
+    closeConcept();
+  });
+
+  useEventListener(popover ? doc : null, 'keydown', (event) => {
+    if (event.key === 'Escape') closeConcept();
+  });
+
+  useEventListener(popover ? win : null, 'resize', closeConcept);
+  useEventListener(popover ? win : null, 'scroll', closeConcept, true);
+
+  const value = useMemo<ConceptGraphContextValue>(
+    () => ({
+      activeConceptId: popover?.conceptId ?? null,
+      openConcept,
+      closeConcept,
+      showConcept,
+      getBacklinks,
+    }),
+    [popover, openConcept, closeConcept, showConcept, getBacklinks],
+  );
+
+  return (
+    <ConceptGraphContext.Provider value={value}>
+      {children}
+      {popover && (
+        <ConceptPopover
+          conceptId={popover.conceptId}
+          top={popover.top}
+          left={popover.left}
+          placement={popover.placement}
+          backlinks={getBacklinks(popover.conceptId)}
+          onShowConcept={showConcept}
+          onClose={closeConcept}
+        />
+      )}
+    </ConceptGraphContext.Provider>
+  );
+};
+
+export default ConceptGraphProvider;

--- a/src/components/Concept/ConceptMention.module.css
+++ b/src/components/Concept/ConceptMention.module.css
@@ -1,0 +1,37 @@
+.mention {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  font: inherit;
+  color: var(--color-text-primary);
+  letter-spacing: inherit;
+  cursor: pointer;
+
+  border-bottom: 1px dotted hsl(0 0% 100% / 0.35);
+  border-radius: 0;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+
+  transition:
+    color var(--duration-fast) var(--ease-smooth),
+    border-color var(--duration-fast) var(--ease-smooth);
+}
+
+.mention:hover,
+.mention:focus-visible {
+  color: var(--color-brand-primary-light);
+  border-bottom-color: var(--color-brand-primary);
+}
+
+.mention:focus-visible {
+  outline-color: var(--color-brand-primary);
+}
+
+.active {
+  color: var(--color-brand-primary-light);
+  border-bottom-color: var(--color-brand-primary);
+  text-shadow: var(--shadow-glow-green);
+}

--- a/src/components/Concept/ConceptMention.tsx
+++ b/src/components/Concept/ConceptMention.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { memo } from 'react';
+import { useAudioManager } from '@/hooks/useAudioManager';
+import { getConcept } from '@/data/concepts';
+import { useConceptGraph } from './ConceptGraphProvider';
+import styles from './ConceptMention.module.css';
+
+interface ConceptMentionProps {
+  conceptId: string;
+  /** Display override from `[[id|display]]`; falls back to the concept title. */
+  display?: string;
+}
+
+const ConceptMention = memo<ConceptMentionProps>(({ conceptId, display }) => {
+  const { playSound } = useAudioManager();
+  const { activeConceptId, openConcept, closeConcept } = useConceptGraph();
+
+  const concept = getConcept(conceptId);
+  if (!concept) {
+    return <>{display ?? conceptId}</>;
+  }
+
+  const active = activeConceptId === conceptId;
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (active) {
+      closeConcept();
+    } else {
+      openConcept(conceptId, event.currentTarget);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`${styles.mention} ${active ? styles.active : ''}`}
+      aria-expanded={active}
+      data-concept-ui
+      onMouseEnter={() => playSound('hover')}
+      onClick={handleClick}
+    >
+      {display ?? concept.title}
+    </button>
+  );
+});
+
+ConceptMention.displayName = 'ConceptMention';
+
+export default ConceptMention;

--- a/src/components/Concept/ConceptPopover.module.css
+++ b/src/components/Concept/ConceptPopover.module.css
@@ -1,0 +1,203 @@
+.popover {
+  /* Anchored panel on desktop; bottom sheet on mobile */
+  position: fixed;
+  top: var(--popover-top);
+  left: var(--popover-left);
+  z-index: var(--z-popover);
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+
+  width: min(320px, calc(100vw - 24px));
+  padding: var(--spacing-4);
+
+  background: hsl(0 0% 7% / 0.97);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xl);
+
+  color: var(--color-text-primary);
+  font-family: var(--font-primary);
+  font-weight: var(--font-weight-light);
+
+  outline: none;
+  animation: popoverIn var(--duration-fast) var(--ease-smooth);
+}
+
+.above {
+  transform: translateY(-100%);
+}
+
+@keyframes popoverIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+}
+
+.meta {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: lowercase;
+  color: var(--color-brand-primary);
+}
+
+.close {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: var(--spacing-1);
+  margin: 0;
+
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast) var(--ease-smooth);
+}
+
+.close:hover,
+.close:focus-visible {
+  color: var(--color-text-primary);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-light);
+  letter-spacing: var(--letter-spacing-wide);
+  line-height: var(--line-height-tight);
+}
+
+.description {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
+}
+
+.resource {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  align-self: flex-start;
+
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--letter-spacing-wide);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: color var(--duration-fast) var(--ease-smooth);
+}
+
+.resource:hover,
+.resource:focus-visible {
+  color: var(--color-brand-primary-light);
+}
+
+.resourceArrow {
+  color: var(--color-brand-primary);
+}
+
+.backlinks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding-top: var(--spacing-2);
+  border-top: 1px solid hsl(0 0% 100% / 0.06);
+}
+
+.backlinksLabel {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: lowercase;
+  color: var(--color-text-tertiary);
+}
+
+.backlinkList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: var(--spacing-3);
+  row-gap: var(--spacing-1);
+}
+
+.backlinkButton {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  font: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  border-bottom: 1px dotted hsl(0 0% 100% / 0.35);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-smooth),
+    border-color var(--duration-fast) var(--ease-smooth);
+}
+
+.backlinkButton:hover,
+.backlinkButton:focus-visible {
+  color: var(--color-brand-primary-light);
+  border-bottom-color: var(--color-brand-primary);
+}
+
+.backlinkText {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* Bottom sheet on mobile — anchor coordinates are ignored */
+@media (max-width: 768px) {
+  .popover,
+  .above {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    transform: none;
+
+    width: auto;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+    border-bottom: none;
+    padding-bottom: calc(var(--spacing-4) + env(safe-area-inset-bottom, 0px));
+
+    animation: sheetIn var(--duration-normal) var(--ease-smooth);
+  }
+
+  .close {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: calc(-1 * var(--spacing-2));
+  }
+
+  @keyframes sheetIn {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover {
+    animation: none;
+  }
+}

--- a/src/components/Concept/ConceptPopover.tsx
+++ b/src/components/Concept/ConceptPopover.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import React from 'react';
+import { useAudioManager } from '@/hooks/useAudioManager';
+import { getConcept } from '@/data/concepts';
+import type { ConceptBacklink } from '@/utils/conceptGraph';
+import styles from './ConceptPopover.module.css';
+
+interface ConceptPopoverProps {
+  conceptId: string;
+  top: number;
+  left: number;
+  placement: 'below' | 'above';
+  backlinks: ConceptBacklink[];
+  onShowConcept: (conceptId: string) => void;
+  onClose: () => void;
+}
+
+function formatTag(tag: string): string {
+  return tag.replace(/-/g, ' ');
+}
+
+const ConceptPopover: React.FC<ConceptPopoverProps> = ({
+  conceptId,
+  top,
+  left,
+  placement,
+  backlinks,
+  onShowConcept,
+  onClose,
+}) => {
+  const { playSound } = useAudioManager();
+  const concept = getConcept(conceptId);
+
+  if (!concept) return null;
+
+  const meta = [concept.type, ...(concept.tags ?? []).map(formatTag)].join(' · ');
+  let resourceHost: string | null = null;
+  if (concept.resource) {
+    try {
+      resourceHost = new URL(concept.resource).hostname;
+    } catch {
+      resourceHost = concept.resource;
+    }
+  }
+
+  return (
+    <div
+      className={`${styles.popover} ${placement === 'above' ? styles.above : ''}`}
+      style={{ '--popover-top': `${top}px`, '--popover-left': `${left}px` } as React.CSSProperties}
+      role="dialog"
+      aria-label={concept.title}
+      data-concept-ui
+      tabIndex={-1}
+      ref={(element) => element?.focus({ preventScroll: true })}
+    >
+      <div className={styles.header}>
+        <span className={styles.meta}>{meta}</span>
+        <button
+          type="button"
+          className={styles.close}
+          aria-label="Close"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+
+      <h3 className={styles.title}>{concept.title}</h3>
+
+      {concept.description && (
+        <p className={styles.description}>{concept.description}</p>
+      )}
+
+      {concept.resource && (
+        <a
+          className={styles.resource}
+          href={concept.resource}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => playSound('click')}
+        >
+          {resourceHost}
+          <span className={styles.resourceArrow} aria-hidden="true">↗</span>
+        </a>
+      )}
+
+      {backlinks.length > 0 && (
+        <div className={styles.backlinks}>
+          <span className={styles.backlinksLabel}>also in</span>
+          <ul className={styles.backlinkList}>
+            {backlinks.map((backlink) => {
+              const about = backlink.aboutConceptId
+                ? getConcept(backlink.aboutConceptId)
+                : undefined;
+              return (
+                <li key={backlink.sourceId}>
+                  {about ? (
+                    <button
+                      type="button"
+                      className={styles.backlinkButton}
+                      onMouseEnter={() => playSound('hover')}
+                      onClick={() => onShowConcept(about.id)}
+                    >
+                      {about.title}
+                    </button>
+                  ) : (
+                    <span className={styles.backlinkText}>{backlink.sourceLabel}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ConceptPopover;

--- a/src/components/Concept/Passage.module.css
+++ b/src/components/Concept/Passage.module.css
@@ -1,0 +1,14 @@
+.passage {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-light);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
+  max-width: 48ch;
+}
+
+@media (max-width: 768px) {
+  .passage {
+    font-size: var(--font-size-base);
+  }
+}

--- a/src/components/Concept/Passage.stories.tsx
+++ b/src/components/Concept/Passage.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Passage from './Passage';
+import ConceptGraphProvider from './ConceptGraphProvider';
+import { VolumeProvider } from '../../context/VolumeContext';
+import { CARD_CONCEPT_SOURCES, CARD_INTERESTS } from '../../data/concepts';
+
+/**
+ * Passage renders prose whose `[[wikilink]]` mentions become tappable
+ * concept links. Tapping a mention opens the shared concept popover with
+ * status, description, outbound link, and derived backlinks.
+ */
+const meta: Meta<typeof Passage> = {
+  title: 'Concept Graph/Passage',
+  component: Passage,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Prose with live concept mentions. Wrap consumers in ConceptGraphProvider so mentions share one popover and backlink index.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <VolumeProvider>
+        <ConceptGraphProvider sources={CARD_CONCEPT_SOURCES}>
+          <div
+            style={{
+              width: '420px',
+              padding: '2rem',
+              background: 'hsl(0 0% 4%)',
+              color: 'hsl(0 0% 90%)',
+            }}
+          >
+            <Story />
+          </div>
+        </ConceptGraphProvider>
+      </VolumeProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CurrentInterests: Story = {
+  args: {
+    section: CARD_INTERESTS,
+  },
+};
+
+export const UnknownConceptFallback: Story = {
+  args: {
+    section: {
+      id: 'story/unknown',
+      label: 'unknown mention',
+      text: 'Mentions of [[not/registered|unregistered concepts]] render as plain text.',
+    },
+  },
+};

--- a/src/components/Concept/Passage.tsx
+++ b/src/components/Concept/Passage.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React, { memo } from 'react';
+import type { CardPassageSection } from '@/data/concepts';
+import WikilinkText from './WikilinkText';
+import styles from './Passage.module.css';
+
+interface PassageProps {
+  section: CardPassageSection;
+}
+
+const Passage = memo<PassageProps>(({ section }) => (
+  <p className={styles.passage}>
+    <WikilinkText text={section.text} />
+  </p>
+));
+
+Passage.displayName = 'Passage';
+
+export default Passage;

--- a/src/components/Concept/WikilinkText.tsx
+++ b/src/components/Concept/WikilinkText.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { parseWikilinks } from '@/utils/wikilinks';
+import ConceptMention from './ConceptMention';
+
+interface WikilinkTextProps {
+  /** Text with `[[concept-id]]` / `[[concept-id|display]]` mentions. */
+  text: string;
+}
+
+const WikilinkText: React.FC<WikilinkTextProps> = ({ text }) => {
+  const segments = useMemo(() => parseWikilinks(text), [text]);
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.kind === 'text' ? (
+          <React.Fragment key={index}>{segment.text}</React.Fragment>
+        ) : (
+          <ConceptMention
+            key={index}
+            conceptId={segment.conceptId}
+            display={segment.display}
+          />
+        ),
+      )}
+    </>
+  );
+};
+
+export default WikilinkText;

--- a/src/components/Concept/index.ts
+++ b/src/components/Concept/index.ts
@@ -1,0 +1,7 @@
+export { default as ConceptGraphProvider, useConceptGraph } from './ConceptGraphProvider';
+export { default as ConceptPopover } from './ConceptPopover';
+export { default as ConceptMention } from './ConceptMention';
+export { default as WikilinkText } from './WikilinkText';
+export { default as Passage } from './Passage';
+export { default as ConceptChip } from './ConceptChip';
+export { default as ChipGroup } from './ChipGroup';

--- a/src/data/concepts.ts
+++ b/src/data/concepts.ts
@@ -1,0 +1,222 @@
+/**
+ * Concept registry — a lightweight personal knowledge graph rendered as text.
+ *
+ * Field names follow the Open Knowledge Format (OKF v0.1 §4.1) so a future
+ * migration to a real OKF bundle (one markdown file per concept) is a
+ * mechanical export: `type` is the one required field; `title`,
+ * `description`, `resource`, and `tags` are the recommended ones. Ids are
+ * path-shaped like OKF concept IDs.
+ *
+ * The registry holds durable identities only. Contextual detail (model
+ * version ranges, model↔harness pairings) is display text on the section
+ * data below, never a node — so the graph doesn't rot per model release.
+ * Status facets (`current-interest`, `learning`, `wishlist`) ride in `tags`,
+ * orthogonal to the graph itself.
+ */
+
+export type ConceptType =
+  | 'tech'
+  | 'tool'
+  | 'model'
+  | 'site'
+  | 'person'
+  | 'project'
+  | 'idea';
+
+export interface Concept {
+  /** Path-shaped id, OKF concept-ID style (`tools/claude-code`). */
+  id: string;
+  type: ConceptType;
+  title: string;
+  description?: string;
+  /** Canonical URI for the underlying asset; absent for abstract ideas. */
+  resource?: string;
+  tags?: string[];
+}
+
+export const CONCEPTS: Concept[] = [
+  {
+    id: 'projects/misipns',
+    type: 'project',
+    title: 'MisiPNS',
+    description: 'Mobile product built with React Native on PostgreSQL.',
+    tags: ['current-interest'],
+  },
+  {
+    id: 'ideas/product-engineering',
+    type: 'idea',
+    title: 'Product Engineering',
+    description: 'Owning the product outcome, not just the ticket.',
+    tags: ['current-interest'],
+  },
+  {
+    id: 'ideas/mobile-development',
+    type: 'idea',
+    title: 'Mobile Development',
+    tags: ['current-interest'],
+  },
+  {
+    id: 'tech/react-native',
+    type: 'tech',
+    title: 'React Native',
+    resource: 'https://reactnative.dev',
+    tags: ['current-interest'],
+  },
+  {
+    id: 'tech/postgresql',
+    type: 'tech',
+    title: 'PostgreSQL',
+    resource: 'https://www.postgresql.org',
+    tags: ['current-interest'],
+  },
+  {
+    id: 'models/gemini',
+    type: 'model',
+    title: 'Gemini',
+    description: 'Google DeepMind model family.',
+  },
+  {
+    id: 'models/glm',
+    type: 'model',
+    title: 'GLM',
+    description: 'Z.ai open-weight model family.',
+  },
+  {
+    id: 'models/claude',
+    type: 'model',
+    title: 'Claude',
+    description: 'Anthropic model family.',
+  },
+  {
+    id: 'tools/copilot',
+    type: 'tool',
+    title: 'GitHub Copilot',
+    resource: 'https://github.com/features/copilot',
+  },
+  {
+    id: 'tools/claude-code',
+    type: 'tool',
+    title: 'Claude Code',
+    description: 'Agentic coding harness in the terminal.',
+    resource: 'https://claude.com/claude-code',
+  },
+  {
+    id: 'tools/opencode',
+    type: 'tool',
+    title: 'opencode',
+    description: 'Open-source agentic coding harness.',
+    resource: 'https://opencode.ai',
+  },
+  {
+    id: 'sites/ryoos',
+    type: 'site',
+    title: 'ryOS',
+    description: 'Ryo Lu’s personal site as an operating system.',
+    resource: 'https://os.ryo.lu',
+  },
+  {
+    id: 'sites/levelsio',
+    type: 'site',
+    title: 'levels.io',
+    description: 'Pieter Levels’ indie-hacker personal site.',
+    resource: 'https://levels.io',
+  },
+];
+
+const CONCEPT_INDEX = new Map(CONCEPTS.map((concept) => [concept.id, concept]));
+
+export function getConcept(id: string): Concept | undefined {
+  return CONCEPT_INDEX.get(id);
+}
+
+/* ------------------------------------------------------------------ */
+/* Card page content — passages and chip sections that mention concepts */
+/* ------------------------------------------------------------------ */
+
+export interface ConceptChipSpec {
+  /** Wikilink-bearing text; free text (version ranges) stays display-only. */
+  label: string;
+  note?: string;
+}
+
+export interface CardPassageSection {
+  id: string;
+  label: string;
+  /** Concept this passage is about — its mentions backlink to this concept. */
+  about?: string;
+  text: string;
+}
+
+export interface CardChipSection {
+  id: string;
+  label: string;
+  chips: ConceptChipSpec[];
+}
+
+/** A unit of the backlink scan: any content block that mentions concepts. */
+export interface ConceptSource {
+  id: string;
+  label: string;
+  about?: string;
+  texts: string[];
+}
+
+export const CARD_INTERESTS: CardPassageSection = {
+  id: 'card/interests',
+  label: 'current interests',
+  about: 'projects/misipns',
+  text:
+    'Currently building [[projects/misipns|MisiPNS]] — hands-on ' +
+    '[[ideas/product-engineering|product engineering]] and ' +
+    '[[ideas/mobile-development|mobile development]] with ' +
+    '[[tech/react-native|React Native]] on [[tech/postgresql|PostgreSQL]].',
+};
+
+export const CARD_COLOPHON: CardChipSection = {
+  id: 'card/colophon',
+  label: 'colophon',
+  chips: [
+    {
+      label: '[[models/gemini|Gemini 2.5 Pro → 3.0]]',
+      note: '[[tools/copilot|Copilot]]',
+    },
+    {
+      label: '[[models/glm|GLM 4.6 → 5.1]]',
+      note: '[[tools/claude-code|Claude Code]] & [[tools/opencode|opencode]]',
+    },
+    {
+      label: '[[models/claude|Claude 3.5 → Fable 5]]',
+      note: '[[tools/claude-code|Claude Code]]',
+    },
+  ],
+};
+
+export const CARD_INSPIRATIONS: CardChipSection = {
+  id: 'card/inspirations',
+  label: 'inspirations',
+  chips: [
+    { label: '[[sites/ryoos]]', note: 'ryo lu' },
+    { label: '[[sites/levelsio]]', note: 'pieter levels' },
+  ],
+};
+
+function chipSectionToSource(section: CardChipSection): ConceptSource {
+  return {
+    id: section.id,
+    label: section.label,
+    texts: section.chips.flatMap((chip) =>
+      chip.note ? [chip.label, chip.note] : [chip.label],
+    ),
+  };
+}
+
+export const CARD_CONCEPT_SOURCES: ConceptSource[] = [
+  {
+    id: CARD_INTERESTS.id,
+    label: CARD_INTERESTS.label,
+    about: CARD_INTERESTS.about,
+    texts: [CARD_INTERESTS.text],
+  },
+  chipSectionToSource(CARD_COLOPHON),
+  chipSectionToSource(CARD_INSPIRATIONS),
+];

--- a/src/utils/conceptGraph.ts
+++ b/src/utils/conceptGraph.ts
@@ -1,0 +1,36 @@
+/**
+ * Backlink index derivation — the graph's edges are mention-derived,
+ * Wikipedia-style: forward links are authored in text, backlinks computed.
+ */
+
+import type { ConceptSource } from '../data/concepts';
+import { extractConceptIds } from './wikilinks';
+
+export interface ConceptBacklink {
+  sourceId: string;
+  sourceLabel: string;
+  /** When the source is about a concept, backlinks point at that concept. */
+  aboutConceptId?: string;
+}
+
+export function buildBacklinkIndex(
+  sources: ConceptSource[],
+): Map<string, ConceptBacklink[]> {
+  const index = new Map<string, ConceptBacklink[]>();
+
+  for (const source of sources) {
+    const mentioned = new Set(source.texts.flatMap(extractConceptIds));
+    for (const conceptId of mentioned) {
+      if (conceptId === source.about) continue;
+      const backlinks = index.get(conceptId) ?? [];
+      backlinks.push({
+        sourceId: source.id,
+        sourceLabel: source.label,
+        aboutConceptId: source.about,
+      });
+      index.set(conceptId, backlinks);
+    }
+  }
+
+  return index;
+}

--- a/src/utils/wikilinks.ts
+++ b/src/utils/wikilinks.ts
@@ -1,0 +1,49 @@
+/**
+ * Wikilink parsing for concept mentions inside plain strings.
+ * Syntax: `[[concept-id]]` or `[[concept-id|display text]]`.
+ */
+
+export interface WikilinkTextSegment {
+  kind: 'text';
+  text: string;
+}
+
+export interface WikilinkMentionSegment {
+  kind: 'mention';
+  conceptId: string;
+  display?: string;
+}
+
+export type WikilinkSegment = WikilinkTextSegment | WikilinkMentionSegment;
+
+const WIKILINK_PATTERN = /\[\[([^[\]|]+)(?:\|([^[\]]+))?\]\]/g;
+
+export function parseWikilinks(text: string): WikilinkSegment[] {
+  const segments: WikilinkSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(WIKILINK_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ kind: 'text', text: text.slice(lastIndex, index) });
+    }
+    segments.push({
+      kind: 'mention',
+      conceptId: match[1].trim(),
+      display: match[2]?.trim(),
+    });
+    lastIndex = index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ kind: 'text', text: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+export function extractConceptIds(text: string): string[] {
+  return parseWikilinks(text)
+    .filter((segment): segment is WikilinkMentionSegment => segment.kind === 'mention')
+    .map((segment) => segment.conceptId);
+}


### PR DESCRIPTION
## Summary
- Adds a reusable "concept" system: a lightweight personal knowledge graph rendered as text, Wikipedia-style — forward links are authored as `[[wikilinks]]`, backlinks are derived automatically from mentions.
- Registry field names follow the Open Knowledge Format (OKF v0.1 §4.1: `type`, `title`, `description`, `resource`, `tags`) with path-shaped ids, so a future migration to a real OKF bundle (one markdown file per concept) stays a mechanical export.
- First surface is `/card`: a **Current interests** prose passage, a **Colophon** of LLM/harness pairs used to build this site, and **Inspirations** linking external sites.

## Changes
- `src/data/concepts.ts` — typed concept registry (durable identities only; version ranges and pairings stay display text so the graph doesn't rot per model release) plus the card's passage/chip content
- `src/utils/wikilinks.ts` — `[[id]]` / `[[id|display]]` parser, no deps
- `src/utils/conceptGraph.ts` — backlink index derived by scanning all registered sources
- `src/components/Concept/` — `ConceptGraphProvider` (context + shared popover host), `Passage`, `ConceptChip`/`ChipGroup`, `ConceptMention`, `WikilinkText`, `ConceptPopover`; CSS modules throughout; Storybook stories for Passage and ChipGroup
- `src/app/card/` — three new sections wired through the provider; fade-up stagger extended
- Interaction: tap a mention/chip → popover with type/status, description, outbound `resource ↗` link, and "also in" backlinks (tappable when the source is about a concept, e.g. PostgreSQL → MisiPNS). Tap outside/Escape/scroll closes. Audio: `hover`/`unfold`/`back`/`click`.

## Test Plan
- `npm run compile`, `npm run lint`, `npm run lint:useeffect`, `npm run build` — all green
- QA on `/card` (mobile-first): tap a mention in "Current interests" → popover opens as bottom sheet at ≤768px, anchored panel on desktop; tap outside or ✕ closes; ≥44px touch targets
- Tap `PostgreSQL` → "also in" shows MisiPNS; tapping it switches the popover in place
- Chips in Colophon/Inspirations: only the wikilinked parts are tappable; version ranges are inert text; `ryOS`/`levels.io` popovers expose outbound links (no direct navigation)
- Verify reduced-motion disables popover/stagger animations and passages still read as prose
- Storybook: `Concept Graph/Passage` and `Concept Graph/ChipGroup` stories render with working popovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)