### PR TITLE
chore: add Warp repository workflows

### DIFF
--- a/.warp/workflows/build.yaml
+++ b/.warp/workflows/build.yaml
@@ -1,0 +1,6 @@
+---
+name: Production build
+command: npm run build
+description: prisma generate + next build + sitemap generation (postbuild).
+tags:
+  - build

--- a/.warp/workflows/dev-server.yaml
+++ b/.warp/workflows/dev-server.yaml
@@ -1,0 +1,7 @@
+---
+name: Dev server
+command: npm run dev
+description: Start the Next.js dev server with Turbopack on port 3000.
+tags:
+  - dev
+  - next

--- a/.warp/workflows/install-deps.yaml
+++ b/.warp/workflows/install-deps.yaml
@@ -1,0 +1,8 @@
+---
+name: Install dependencies
+command: npm install --legacy-peer-deps
+description: >-
+  Install with --legacy-peer-deps — required in this repo (peer-dep conflicts
+  until the Storybook 9 upgrade); a plain npm install will fail.
+tags:
+  - setup

--- a/.warp/workflows/lint.yaml
+++ b/.warp/workflows/lint.yaml
@@ -1,0 +1,6 @@
+---
+name: Lint
+command: npm run lint
+description: ESLint (next/core-web-vitals + storybook rules).
+tags:
+  - check

--- a/.warp/workflows/new-feature-branch.yaml
+++ b/.warp/workflows/new-feature-branch.yaml
@@ -1,0 +1,12 @@
+---
+name: New feature branch
+command: git checkout dev && git pull && git checkout -b {{branch}} dev
+description: >-
+  Start work the repo way: sync dev, then branch from it. Feature branches
+  merge back into dev via PR. Requires a shell with && (PowerShell 7 / bash).
+arguments:
+  - name: branch
+    description: Branch name (feat/..., fix/..., chore/...)
+    default_value: feat/
+tags:
+  - git

--- a/.warp/workflows/pr-into-dev.yaml
+++ b/.warp/workflows/pr-into-dev.yaml
@@ -1,0 +1,9 @@
+---
+name: Open PR into dev
+command: gh pr create --base dev --web
+description: >-
+  Push the current branch first, then open a browser-prefilled PR against dev
+  (the integration branch — main is release only).
+tags:
+  - git
+  - github

--- a/.warp/workflows/prisma-db-push.yaml
+++ b/.warp/workflows/prisma-db-push.yaml
@@ -1,0 +1,9 @@
+---
+name: Prisma db push
+command: npx -y dotenv-cli -e .env.local -- npx prisma db push
+description: >-
+  Sync prisma/schema.prisma to Neon. This repo uses db push, not migrate dev,
+  and env vars load only from .env.local via dotenv-cli.
+tags:
+  - db
+  - prisma

--- a/.warp/workflows/prisma-studio.yaml
+++ b/.warp/workflows/prisma-studio.yaml
@@ -1,0 +1,7 @@
+---
+name: Prisma Studio
+command: npx -y dotenv-cli -e .env.local -- npx prisma studio
+description: Browse the Neon database in Prisma Studio (env from .env.local).
+tags:
+  - db
+  - prisma

--- a/.warp/workflows/react-scan.yaml
+++ b/.warp/workflows/react-scan.yaml
@@ -1,0 +1,13 @@
+---
+name: React Scan
+command: npx react-scan@latest {{url}}
+description: >-
+  Profile re-renders against the running dev server. CLI-only by policy —
+  never add react-scan to the repo as a dependency or script tag.
+arguments:
+  - name: url
+    description: Page to scan
+    default_value: http://localhost:3000
+tags:
+  - perf
+  - debug

--- a/.warp/workflows/storybook.yaml
+++ b/.warp/workflows/storybook.yaml
@@ -1,0 +1,7 @@
+---
+name: Storybook
+command: npm run storybook
+description: Component development environment on port 6006.
+tags:
+  - dev
+  - storybook

--- a/.warp/workflows/typecheck.yaml
+++ b/.warp/workflows/typecheck.yaml
@@ -1,0 +1,6 @@
+---
+name: Typecheck
+command: npm run compile
+description: TypeScript type checking (tsc, no emit).
+tags:
+  - check

--- a/.warp/workflows/useeffect-policy.yaml
+++ b/.warp/workflows/useeffect-policy.yaml
@@ -1,0 +1,8 @@
+---
+name: useEffect policy check
+command: npm run lint:useeffect
+description: >-
+  Enforce the no-direct-useEffect policy — every useEffect in components/app
+  must be refactored to a custom hook or tagged with an effect:audited comment.
+tags:
+  - check

--- a/.warp/workflows/verify-all.yaml
+++ b/.warp/workflows/verify-all.yaml
@@ -1,0 +1,9 @@
+---
+name: Verify all
+command: npm run compile && npm run lint && npm run lint:useeffect
+description: >-
+  Fail-fast pre-PR gate: typecheck, then ESLint, then the useEffect policy
+  check. Requires a shell with && (PowerShell 7 / bash / zsh).
+tags:
+  - check
+  - ci


### PR DESCRIPTION
## Summary
- Adds 13 Warp repository workflows under `.warp/workflows/` — Warp surfaces these in the command palette/workflow search whenever a session is inside this repo.
- Each workflow encodes a real repo convention, including the non-obvious ones: `--legacy-peer-deps` installs, prisma through `dotenv-cli -e .env.local` (`db push`, never `migrate dev`), react-scan as CLI-only, and the branch-from-`dev` / PR-into-`dev` git flow.

## Workflows
| Category | Workflows |
|---|---|
| Run | Dev server, Storybook |
| Check | Typecheck, Lint, useEffect policy check, Verify all (fail-fast chain) |
| Build/Setup | Production build, Install dependencies (`--legacy-peer-deps`) |
| Database | Prisma db push, Prisma Studio (both via `dotenv-cli -e .env.local`) |
| Debug | React Scan (parameterized URL, defaults to localhost:3000) |
| Git | New feature branch (parameterized, branches from synced `dev`), Open PR into dev (`gh pr create --base dev --web`) |

## Test Plan
- All 13 files parse as valid YAML with required `name`/`command` fields and argument placeholders matching `{{arg}}` templates (validated in CI-style check locally)
- In Warp: open the repo, search any workflow name in the command palette; `React Scan` and `New feature branch` should prompt for their arguments
- Note: `Verify all` and `New feature branch` use `&&`, which needs PowerShell 7 / bash / zsh (Warp's supported shells) — not Windows PowerShell 5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)