### PR TITLE
fix(auth): trust production origins for better-auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,13 @@ import { db } from "../utils/db";
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000",
-  trustedOrigins: ["http://localhost:3000"],
+  trustedOrigins: [
+    "http://localhost:3000",
+    "https://sorosfebria.co",
+    "https://www.sorosfebria.co",
+    "https://s11o.online",
+    "https://www.s11o.online",
+  ],
   database: prismaAdapter(db, { provider: "postgresql" }),
   socialProviders: {
     github: {


### PR DESCRIPTION
## Summary
- Add production domains (`sorosfebria.co` and `s11o.online`, apex + www) to better-auth `trustedOrigins`
- Keeps `localhost:3000` for local dev
- Without this, sign-in fails better-auth's origin/CSRF checks once deployed

## Test plan
- `npm run compile` passes
- QA on dev: local sign-in flow should behave exactly as before (localhost still trusted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)