### PR TITLE
fix(build): commit .npmrc so Vercel installs with legacy-peer-deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
Production deploy of #24 failed at `npm install` with ERESOLVE: `@storybook/nextjs@7` peers on `next@^9–13` while the app is on `next@15`. Local installs already use `--legacy-peer-deps`; this commits `.npmrc` with `legacy-peer-deps=true` so Vercel (and fresh clones) resolve the same way.

Temporary until Storybook is upgraded to a Next 15-compatible major.

## Test plan
- Vercel build proceeds past install on the follow-up release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)