### PR TITLE
release: fix Vercel install (legacy-peer-deps)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Follow-up to #24 — its production build failed at `npm install` (ERESOLVE, storybook 7 vs next 15). Ships `.npmrc` with `legacy-peer-deps=true` (#25) so the deploy can complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)