### PR TITLE
feat(card): link the colophon through to the release history page

### DIFF
--- a/src/components/GamerCard/panes/AboutPane.tsx
+++ b/src/components/GamerCard/panes/AboutPane.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { memo } from 'react';
-import { Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import { ScrollText, Sparkles } from 'lucide-react';
 import {
   CARD_COLOPHON,
   CARD_GEAR,
@@ -9,6 +10,8 @@ import {
   CARD_INTERESTS,
   CARD_LIKES,
 } from '../../../data/concepts';
+import { useAudioManager } from '@/hooks/useAudioManager';
+import { useNavigationSound } from '@/hooks/useNavigationSound';
 import { ChipGroup, Passage } from '../../Concept';
 import styles from './panes.module.css';
 
@@ -18,6 +21,9 @@ import styles from './panes.module.css';
  * All mentions share the popover hosted by ConceptGraphProvider.
  */
 const AboutPane = memo(() => {
+  const { playSound } = useAudioManager();
+  const { playNavigationSound } = useNavigationSound();
+
   return (
     <div className={styles.pane}>
       <div className={styles.paneHeader}>
@@ -49,6 +55,15 @@ const AboutPane = memo(() => {
         <div className={styles.skillGroup}>
           <h3 className={styles.skillGroupLabel}>Colophon</h3>
           <ChipGroup chips={CARD_COLOPHON.chips} />
+          <Link
+            href="/changelog"
+            className={styles.colophonLink}
+            onClick={playNavigationSound}
+            onMouseEnter={() => playSound('hover')}
+          >
+            <ScrollText size={14} strokeWidth={1.5} aria-hidden />
+            <span>System Update — what shipped, and when</span>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/GamerCard/panes/panes.module.css
+++ b/src/components/GamerCard/panes/panes.module.css
@@ -206,6 +206,38 @@
   color: var(--color-text-secondary);
 }
 
+/* Colophon footer link through to the release history page */
+.colophonLink {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: var(--spacing-2);
+  min-height: 44px;
+  padding: var(--spacing-1) 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--letter-spacing-wide);
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition: color var(--duration-fast) var(--ease-smooth);
+}
+
+.colophonLink:hover,
+.colophonLink:focus-visible {
+  color: var(--color-brand-primary-light);
+}
+
+.colophonLink:focus-visible {
+  outline-color: var(--color-brand-primary);
+}
+
+.colophonLink svg {
+  flex-shrink: 0;
+}
+
 .educationLine {
   margin: 0;
   display: flex;


### PR DESCRIPTION
Closes the last open bullet of SOR-82's plan: the `/changelog` page shipped in #27 with **no route into it from the site**.

## What

Adds a link from the /card Colophon group through to `/changelog`.

- Uses a real `next/link` anchor rather than a click-handled `div`, so the link stays keyboard- and middle-click-navigable. (SOR-83 flags click-handler divs as a live a11y bug elsewhere on the card — not repeating it here.)
- Standard `playNavigationSound` + `hover` audio, per the audio-feedback rule.
- Token-only styling, 44px tap target.

## Checks

- `npx tsc --noEmit` — clean
- `next lint` — no warnings or errors
- `npm run lint:css` — **0 errors, 1362 warnings** (baseline is 1363; no new warnings introduced)

## Note

This does not itself trigger a release — release-please has never run, because #27 landed on `dev` and the workflow only registers from the default branch. The follow-up `dev` -> `main` PR fixes that.

Refs SOR-82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)